### PR TITLE
Change: fix always_ff snippet containing extra "}"

### DIFF
--- a/snippets/systemverilog.json
+++ b/snippets/systemverilog.json
@@ -17,7 +17,7 @@
         "prefix": "always_ff",
         "description": "Snippet for an always_comb block",
         "body": [
-            "always_ff @(posedge ${1:ck}, posedge ${2:arst})} begin",
+            "always_ff @(posedge ${1:ck}, posedge ${2:arst}) begin",
             "\t$0",
             "end"
         ]


### PR DESCRIPTION
The always_ff snippet had an extra '}' after the posedge. This caused syntax error in simulators. I removed it since it does not seem to be useful.