### PR TITLE
Don't lookup symbol in provideHover when the range is undefined

### DIFF
--- a/src/providers/HoverProvider.ts
+++ b/src/providers/HoverProvider.ts
@@ -15,16 +15,18 @@ export class SystemVerilogHoverProvider implements vscode.HoverProvider {
     provideHover(document : vscode.TextDocument, position : vscode.Position, token: vscode.CancellationToken) : vscode.ProviderResult<vscode.Hover> {
         return new Promise( (resolve, reject) => {
             var lookupRange = document.getWordRangeAtPosition(position);
-            var lookupTerm = document.getText(lookupRange);
             
             if (!lookupRange) {
-                resolve(undefined);
+                return resolve(undefined);
             }
+            
+            var lookupTerm = document.getText(lookupRange);
+            
             // First, lookup in the current document
             return this.docSymProvider.provideDocumentSymbols(document).then(docSyms => {
                 docSyms.forEach(docSym => {
                     if(docSym.name === lookupTerm) {
-                        resolve(buildHover(document, docSym, lookupRange));
+                        return resolve(buildHover(document, docSym, lookupRange));
                     }
                 });
 


### PR DESCRIPTION
The current check doesn't prevent it trying the lookup anyway, which usually results in an error constructing a regex from the whole file.