### PR TITLE
Improving syntax highlighting support for UDP tables

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -12,6 +12,7 @@ patterns:
   - include: '#typedef'
   - include: '#functions'
   - include: '#keywords'
+  - include: '#tables'
   - include: '#function-task'
   - include: '#module-declaration'
   - include: '#class-declaration'
@@ -249,7 +250,7 @@ repository:
   keywords:
     patterns:
       - match: >-
-          [ \t\r\n]*\b(edge|negedge|posedge|cell|config|defparam|design|disable|endgenerate|endspecify|endtable|event|generate|ifnone|incdir|instance|liblist|library|noshowcancelled|pulsestyle_onevent|pulsestyle_ondetect|scalared|showcancelled|specify|specparam|table|use|vectored)\b
+          [ \t\r\n]*\b(edge|negedge|posedge|cell|config|defparam|design|disable|endgenerate|endspecify|event|generate|ifnone|incdir|instance|liblist|library|noshowcancelled|pulsestyle_onevent|pulsestyle_ondetect|scalared|showcancelled|specify|specparam|use|vectored)\b
         captures:
           '1':
             name: keyword.other.systemverilog
@@ -733,3 +734,29 @@ repository:
           - include: '#operators'
           - include: '#identifiers'
     name: meta.import.systemverilog
+  tables:
+    begin: '[ \t\r\n]*\b(table)\b'
+    beginCaptures:
+      '1':
+        name: keyword.table.systemverilog.begin
+    end: '[ \t\r\n]*\b(endtable)\b'
+    endCaptures:
+      '1':
+        name: keyword.table.systemverilog.end
+    patterns:
+      - include: '#comments'
+      - match: '\b[01xXbBrRfFpPnN]\b'
+        name: constant.language.systemverilog
+      - match: '[-*?]'
+        name: constant.language.systemverilog
+      - match: '\(([01xX?]{2})\)'
+        captures:
+          '1':
+            name: constant.language.systemverilog
+      - match: ':'
+        name: punctuation.definition.label.systemverilog
+      - include: '#operators'
+      - include: '#constants'
+      - include: '#strings'
+      - include: '#identifiers'
+    name: meta.table.systemverilog

--- a/verilog-examples/primitive_table.sv
+++ b/verilog-examples/primitive_table.sv
@@ -1,0 +1,11 @@
+primitive MyUDP (x, a, b, c);
+  output x;
+  input a, b, c;
+  table
+   // a  b   c   :  x
+      0  n   P   :  0;
+      1  ?  (10) :  1;
+      *  0   x   :  -;
+      ?  1   1   :  1;
+  endtable
+endprimitive


### PR DESCRIPTION
This PR adds more consistent syntax highlighting for UDP tables, which have their own set of keywords (0, 1, x/X, ?, b/B, -, r/R, f/F, p/P, n/N, and (xy)).

Before:
<img width="158" alt="UDP before" src="https://user-images.githubusercontent.com/7417975/138561735-57d7f55f-70fa-4614-886b-54f8ac9d262f.png">

After:
<img width="155" alt="UDP after" src="https://user-images.githubusercontent.com/7417975/138561722-03e038fd-fc6b-467a-98de-7beff1d46e79.png">

I'm participating in [Hacktoberfest](https://hacktoberfest.digitalocean.com/), so would you mind adding the `hacktoberfest-accepted` tag to the PR if it looks OK? Thanks!