### PR TITLE
adding `compileOnOpen` setting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ This VS Code extension provides features to read, navigate and write SystemVeril
 - `systemverilog.compilerType`: _String_, Dropdown list to select a compiler type
   - Default: `Verilator`
 - `systemverilog.trace.server`: _String_, Dropdown to select verbosity of LSP message tracing
+- `systemverilog.compileOnOpen`: _Boolean_, Compile all files when opened
+  - Default: `false`
 
 ### Customizations
 

--- a/package.json
+++ b/package.json
@@ -215,7 +215,12 @@
                         "type": "boolean",
                         "default": false,
                         "description": "Run ANTLR verification on all files when opened."
-                    }
+                    },
+                    "systemverilog.compileOnOpen": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Compile all files when opened."
+                  }
                 }
             }
         ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,8 @@ const compilerConfigurationsKeys: string[] = [
     'systemverilog.launchConfigurationVerible',
     'systemverilog.antlrVerification',
     'systemverilog.verifyOnOpen',
-    'systemverilog.excludeCompiling'
+    'systemverilog.excludeCompiling',
+    'systemverilog.compileOnOpen'
 ];
 
 const backend: ANTLRBackend = new ANTLRBackend();
@@ -115,7 +116,7 @@ function updateConfigurationsSettings(): Promise<any> {
 }
 
 /**
- *	If `compileOnSave` is set to true, the server will compile the document.
+ *	If `compileOnSave` and/or `compileOnOpen` is set to true, the server will compile the document.
  *
  *  @param saveEvent An object containing information about the saved file
  */
@@ -171,6 +172,10 @@ documents.onDidOpen(async (openEvent) => {
     if (configurations.get(compilerConfigurationsKeys[6])) {
         // Check for verifyOnOpen being true
         verifyDocument(openEvent.document.uri);
+    }
+    if (configurations.get(compilerConfigurationsKeys[8])) {
+        // Check for compileOnOpen being true
+        compile(openEvent.document);
     }
 });
 


### PR DESCRIPTION
First of all, thank you for this awesome VSCode extension 💯 

I think the option `compileOnOpen` should enhance the experience. It can, when one uses `verilator` for example, completely replace the ANTLR e.g. `verifyOnOpen` option. 

I used it with `launchConfigurationVerilator` where I add my import paths with `-I`.

Cheers
Jannis