### PR TITLE
fix: #177: Properly handle Windows paths in Verilator output

### DIFF
--- a/src/compiling/VerilatorCompiler.ts
+++ b/src/compiling/VerilatorCompiler.ts
@@ -21,15 +21,28 @@ enum CannotFindModuleState {
  * and eventually parses the errors/warnings in `stderr` into `Diagnostic` array mapped to each unique document's uri.
  */
 export class VerilatorCompiler extends DocumentCompiler {
+    errorPrefixRegex = '%Error';
+
+    // Match file path, with possible Windows drive letter and colon prefix. Example: '/foo/bar' or 'c:/foo/bar'
+    filePathRegex = '((?:\\w:)?[^:]*)';
+
+    // Matches line number, and column number of it exists. Example: '1034' or '1034:20'
+    lineNumberAndPossibleColumnRegex = '([0-9]+)(:[0-9]+)?';
+
+    fileAndLineNumberRegex = `${this.filePathRegex}:${this.lineNumberAndPossibleColumnRegex}`;
+
     // Regular expressions
-    regexError = new RegExp('%Error: ([^:]*):([0-9]+)(:[0-9]+)?: (.*)');
-    regexErrorWarning = new RegExp('%Error-(.*): ([^:]*):([0-9]+)(:[0-9]+)?: (.*)');
-    regexWarning = new RegExp('%Warning-(.*): ([^:]*):([0-9]+)(:[0-9]+)?: (.*)');
+    regexError = new RegExp(`${this.errorPrefixRegex}: ${this.fileAndLineNumberRegex}: (.*)`);
+    regexErrorWarning = new RegExp(`${this.errorPrefixRegex}-(.*): ${this.fileAndLineNumberRegex}: (.*)`);
+    regexWarning = new RegExp(`%Warning-(.*): ${this.fileAndLineNumberRegex}: (.*)`);
     regexWarningSuggest = new RegExp('%Warning-(.*): (.*)');
-    regexCannotFindModule = new RegExp('%Error: ([^:]*):([0-9]+)(:[0-9]+)?: Cannot find(.*): (.*)');
-    regexSearchPathNotFound = new RegExp("%Error: ([^:]*):([0-9]+)(:[0-9]+)?: This may be because there's no search path specified with -I<dir>."); // prettier-ignore
-    regexLookedIn = new RegExp('%Error: ([^:]*):([0-9]+)(:[0-9]+)?: Looked in:');
-    regexFilesSearchedSource = '%Error: ([^:]*):([0-9]+)(:[0-9]+)?:       (.*)notFoundModulePlaceHolder(.v|.sv|.vh|.svh|)$'; // prettier-ignore
+    regexCannotFindModule = new RegExp(
+        `${this.errorPrefixRegex}: ${this.fileAndLineNumberRegex}: Cannot find(.*): (.*)`
+    );
+
+    regexSearchPathNotFound = new RegExp(`${this.errorPrefixRegex}: ${this.fileAndLineNumberRegex}: This may be because there's no search path specified with -I<dir>.`); // prettier-ignore
+    regexLookedIn = new RegExp(`${this.errorPrefixRegex}: ${this.fileAndLineNumberRegex}: Looked in:`);
+    regexFilesSearchedSource = `${this.errorPrefixRegex}: ${this.fileAndLineNumberRegex}:       (.*)notFoundModulePlaceHolder(.v|.sv|.vh|.svh|)$`; // prettier-ignore
     regexOffendPart = new RegExp(".*'(.*)'.*");
 
     /**

--- a/src/test/VerilatorCompiler.test.ts
+++ b/src/test/VerilatorCompiler.test.ts
@@ -12,7 +12,13 @@ const testFolderLocation = '../../src/test/test-files/VerilatorCompiler.test';
 const filePathPlaceholder = 'FILEPATH_PLACEHOLDER';
 
 let diagnosticCollection: Map<string, Diagnostic[]>;
-const documentCompiler = new VerilatorCompiler(undefined, undefined, undefined, undefined, undefined);
+const documentCompiler = new VerilatorCompiler(
+    undefined,
+    undefined,
+    path.join(__dirname, '../../'),
+    undefined,
+    undefined
+);
 
 suite('VerilatorCompiler Tests', () => {
     test('test #1: Diagnostics from %Error', async () => {
@@ -25,7 +31,7 @@ suite('VerilatorCompiler Tests', () => {
 
         const document: TextDocument = castTextDocument(documentWorkspace);
 
-        const compiledFilePath = getPathFromUri(document.uri, __dirname);
+        const compiledFilePath = getPathFromUri(document.uri, __dirname) || document.uri;
 
         const stderrFile = path.join(__dirname, testFolderLocation, 'foo.stderr.txt');
 
@@ -55,7 +61,7 @@ suite('VerilatorCompiler Tests', () => {
 
         const document: TextDocument = castTextDocument(documentWorkspace);
 
-        const compiledFilePath = getPathFromUri(document.uri, __dirname);
+        const compiledFilePath = getPathFromUri(document.uri, __dirname) || document.uri;
 
         const stderrFile = path.join(__dirname, testFolderLocation, 'bar.stderr.txt');
 
@@ -88,7 +94,7 @@ suite('VerilatorCompiler Tests', () => {
 
         const document: TextDocument = castTextDocument(documentWorkspace);
 
-        const compiledFilePath = getPathFromUri(document.uri, __dirname);
+        const compiledFilePath = getPathFromUri(document.uri, __dirname) || document.uri;
 
         documentCompiler.parseDiagnostics(undefined, undefined, '', document, compiledFilePath, diagnosticCollection);
 
@@ -106,7 +112,7 @@ suite('VerilatorCompiler Tests', () => {
 
         let uriDoc = Uri.file(path.join(__dirname, testFolderLocation, filePath));
         let document = await workspace.openTextDocument(uriDoc);
-        let compiledFilePath = getPathFromUri(document.uri.toString(), __dirname);
+        let compiledFilePath = getPathFromUri(document.uri.toString(), __dirname) || document.uri;
 
         let stderr = fs.readFileSync(stderrFile).toString();
         stderr = stderrSetUp(stderr, compiledFilePath);
@@ -125,7 +131,7 @@ suite('VerilatorCompiler Tests', () => {
 
         uriDoc = Uri.file(path.join(__dirname, testFolderLocation, filePath));
         document = await workspace.openTextDocument(uriDoc);
-        compiledFilePath = getPathFromUri(document.uri.toString(), __dirname);
+        compiledFilePath = getPathFromUri(document.uri.toString(), __dirname) || document.uri;
 
         stderr = fs.readFileSync(stderrFile).toString();
         stderr = stderrSetUp(stderr, compiledFilePath);


### PR DESCRIPTION
Windows paths were not being handled in Verilator output, preventing the lint results from appearing.

Additionally, the tests were not fully testing the lint output, and did not include Windows path styles on any OS.