### PR TITLE
DefinitionProvider bugfixes

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -158,12 +158,12 @@ export class SystemVerilogParser {
 
     private r_params: RegExp = new RegExp(
         [
-            /(?<type>parameter)\s+/,
-            /(?:(?<data_type>\w+\s*)*?)/,
+            /(?<type>parameter)/,
+            /(?:(\s+(?<data_type>\w+))*)/,
             // Multi-dimensional arrays
-            /(?:\[.*?\]\s*)*?/,
+            /(?:\s*\[.*?\]\s*)*?/,
             // Multiple declaration not allowed (yet)
-            /(?<name>\w+)\s*/
+            /\s+(?<name>\w+)\s*/
             // Don't track the value, too many branches
         ]
             .map((x) => (typeof x === 'string' ? x : x.source))

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -59,8 +59,7 @@ export class SystemVerilogDefinitionProvider implements DefinitionProvider {
                             return commands
                                 .executeCommand('vscode.executeDocumentSymbolProvider', uri, word)
                                 .then((symbols: Array<DocumentSymbol | SymbolInformation>) => {
-                                    results.concat(extractLocations(symbols, word, uri, matchPackage[1]));
-                                    resolve(results);
+                                    resolve(extractLocations(symbols, word, uri, matchPackage[1]));
                                 });
                         } else {
                             resolve(undefined);

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -31,15 +31,16 @@ export class SystemVerilogDefinitionProvider implements DefinitionProvider {
                     commands
                         .executeCommand('vscode.executeWorkspaceSymbolProvider', `¤${container}`)
                         .then((res: SymbolInformation[]) => {
-                            const locationPromises = res.map(x => {
-                                return commands.executeCommand('vscode.executeDocumentSymbolProvider', x.location.uri, word)
-                                .then((symbols: Array<SymbolInformation | DocumentSymbol>) => {
-                                    return extractLocations(symbols, word, x.location.uri, container)
-                                });
+                            const locationPromises = res.map((x) => {
+                                return commands
+                                    .executeCommand('vscode.executeDocumentSymbolProvider', x.location.uri, word)
+                                    .then((symbols: Array<SymbolInformation | DocumentSymbol>) => {
+                                        return extractLocations(symbols, word, x.location.uri, container);
+                                    });
                             });
 
-                            Promise.all(locationPromises).then((locLists:Location[][]) => {
-                                locLists.forEach((locList:Location[]) => results.push(...locList));
+                            Promise.all(locationPromises).then((locLists: Location[][]) => {
+                                locLists.forEach((locList: Location[]) => results.push(...locList));
                                 resolve(results);
                             });
                         });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -59,4 +59,135 @@ suite('Extension Tests', () => {
             assert.strictEqual(0, definition.length);
         }
     });
+
+    test('test #5: DefinitionProvider Parameter', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'parameter_test.sv'));
+
+        // Parameter: EMPTY_PARAMETER
+        const symbolPosition = new vscode.Position(23, 23);
+        const expected = new vscode.Range(10, 4, 10, 29);
+
+        const definition = (await vscode.commands.executeCommand(
+            'vscode.executeDefinitionProvider',
+            uri,
+            symbolPosition
+        )) as vscode.Location[];
+
+        if('length' in definition && definition.length > 0) {
+            assert.deepStrictEqual(
+                expected,
+                definition[0].range,
+                "Expected: " + JSON.stringify(expected) + " Got: " + JSON.stringify(definition[0].range)
+            );
+        } else {
+            assert.fail("Definition not found");
+        }
+    });
+
+    test('test #6: DefinitionProvider Typed Parameter', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'parameter_test.sv'));
+
+        // Parameter: int unsigned INT_UNSIGNED_PARAMETER
+        const symbolPosition = new vscode.Position(28, 24);
+        const expected = new vscode.Range(15, 4, 15, 50);
+
+        const definition = (await vscode.commands.executeCommand(
+            'vscode.executeDefinitionProvider',
+            uri,
+            symbolPosition
+        )) as vscode.Location[];
+
+        if('length' in definition && definition.length > 0) {
+            assert.deepStrictEqual(
+                expected,
+                definition[0].range,
+                "Expected: " + JSON.stringify(expected) + " Got: " + JSON.stringify(definition[0].range)
+            );
+        } else {
+            assert.fail("Definition not found");
+        }
+    });
+
+    test('test #7: DefinitionProvider Typed Array Parameter', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'parameter_test.sv'));
+
+        // Parameter: bit [31:0] BIT_ARRAY_PARAMETER
+        const symbolPosition = new vscode.Position(26, 24);
+        const expected = new vscode.Range(13, 4, 13, 45);
+
+        const definition = (await vscode.commands.executeCommand(
+            'vscode.executeDefinitionProvider',
+            uri,
+            symbolPosition
+        )) as vscode.Location[];
+
+        if('length' in definition && definition.length > 0) {
+            assert.deepStrictEqual(
+                expected,
+                definition[0].range,
+                "Expected: " + JSON.stringify(expected) + " Got: " + JSON.stringify(definition[0].range)
+            );
+        } else {
+            assert.fail("Definition not found");
+        }
+    });
+
+    test('test #8: DefinitionProvider Package Parameter', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'parameter_test.sv'));
+        const expectedUri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'package.sv'));
+
+        // Note: For some reason, the package parameters have a different range than other parameters.
+        // Seems like package parameter range only cover the name of the parameter and potentially the equal sign.
+        // Other parameters have included 'parameter' and the type in the range.
+
+        // Parameter: pa_Package::PARAMETER
+        const symbolPosition = new vscode.Position(16, 56);
+        const expectedRange = new vscode.Range(2, 12, 2, 25);
+
+        const definition = (await vscode.commands.executeCommand(
+            'vscode.executeDefinitionProvider',
+            uri,
+            symbolPosition
+        )) as vscode.Location[];
+
+        if('length' in definition && definition.length > 0) {
+            assert.deepStrictEqual(
+                expectedRange,
+                definition[0].range,
+                "Expected: " + JSON.stringify(expectedRange) + " Got: " + JSON.stringify(definition[0].range)
+            );
+
+            assert.strictEqual(
+                expectedUri.path,
+                definition[0].uri.path,
+                "Expected: " + expectedUri.path + " Got: " + definition[0].uri.path
+            );
+        } else {
+            assert.fail("Definition not found");
+        }
+    });
+
+    test('test #9: DefinitionProvider Port', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'parameter_test.sv'));
+
+        // Port: dataIn
+        const symbolPosition = new vscode.Position(45, 6);
+        const expected = new vscode.Range(1, 4, 1, 16);
+
+        const definition = (await vscode.commands.executeCommand(
+            'vscode.executeDefinitionProvider',
+            uri,
+            symbolPosition
+        )) as vscode.Location[];
+
+        if('length' in definition && definition.length > 0) {
+            assert.deepStrictEqual(
+                expected,
+                definition[0].range,
+                "Expected: " + JSON.stringify(expected) + " Got: " + JSON.stringify(definition[0].range)
+            );
+        } else {
+            assert.fail("Definition not found");
+        }
+    });
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -73,14 +73,14 @@ suite('Extension Tests', () => {
             symbolPosition
         )) as vscode.Location[];
 
-        if('length' in definition && definition.length > 0) {
+        if ('length' in definition && definition.length > 0) {
             assert.deepStrictEqual(
                 expected,
                 definition[0].range,
-                "Expected: " + JSON.stringify(expected) + " Got: " + JSON.stringify(definition[0].range)
+                'Expected: ' + JSON.stringify(expected) + ' Got: ' + JSON.stringify(definition[0].range)
             );
         } else {
-            assert.fail("Definition not found");
+            assert.fail('Definition not found');
         }
     });
 
@@ -97,14 +97,14 @@ suite('Extension Tests', () => {
             symbolPosition
         )) as vscode.Location[];
 
-        if('length' in definition && definition.length > 0) {
+        if ('length' in definition && definition.length > 0) {
             assert.deepStrictEqual(
                 expected,
                 definition[0].range,
-                "Expected: " + JSON.stringify(expected) + " Got: " + JSON.stringify(definition[0].range)
+                'Expected: ' + JSON.stringify(expected) + ' Got: ' + JSON.stringify(definition[0].range)
             );
         } else {
-            assert.fail("Definition not found");
+            assert.fail('Definition not found');
         }
     });
 
@@ -121,14 +121,14 @@ suite('Extension Tests', () => {
             symbolPosition
         )) as vscode.Location[];
 
-        if('length' in definition && definition.length > 0) {
+        if ('length' in definition && definition.length > 0) {
             assert.deepStrictEqual(
                 expected,
                 definition[0].range,
-                "Expected: " + JSON.stringify(expected) + " Got: " + JSON.stringify(definition[0].range)
+                'Expected: ' + JSON.stringify(expected) + ' Got: ' + JSON.stringify(definition[0].range)
             );
         } else {
-            assert.fail("Definition not found");
+            assert.fail('Definition not found');
         }
     });
 
@@ -150,20 +150,20 @@ suite('Extension Tests', () => {
             symbolPosition
         )) as vscode.Location[];
 
-        if('length' in definition && definition.length > 0) {
+        if ('length' in definition && definition.length > 0) {
             assert.deepStrictEqual(
                 expectedRange,
                 definition[0].range,
-                "Expected: " + JSON.stringify(expectedRange) + " Got: " + JSON.stringify(definition[0].range)
+                'Expected: ' + JSON.stringify(expectedRange) + ' Got: ' + JSON.stringify(definition[0].range)
             );
 
             assert.strictEqual(
                 expectedUri.path,
                 definition[0].uri.path,
-                "Expected: " + expectedUri.path + " Got: " + definition[0].uri.path
+                'Expected: ' + expectedUri.path + ' Got: ' + definition[0].uri.path
             );
         } else {
-            assert.fail("Definition not found");
+            assert.fail('Definition not found');
         }
     });
 
@@ -180,14 +180,14 @@ suite('Extension Tests', () => {
             symbolPosition
         )) as vscode.Location[];
 
-        if('length' in definition && definition.length > 0) {
+        if ('length' in definition && definition.length > 0) {
             assert.deepStrictEqual(
                 expected,
                 definition[0].range,
-                "Expected: " + JSON.stringify(expected) + " Got: " + JSON.stringify(definition[0].range)
+                'Expected: ' + JSON.stringify(expected) + ' Got: ' + JSON.stringify(definition[0].range)
             );
         } else {
-            assert.fail("Definition not found");
+            assert.fail('Definition not found');
         }
     });
 });

--- a/verilog-examples/parameter_test.sv
+++ b/verilog-examples/parameter_test.sv
@@ -1,0 +1,51 @@
+module portTest (
+    input dataIn,
+    output dataOut
+);
+
+assign dataOut = dataIn + 1;
+
+endmodule
+
+module parameterTest #(
+    parameter EMPTY_PARAMETER,
+    parameter DEFINED_PARAMETER = 1,
+    parameter bit BIT_PARAMETER = 1,
+    parameter bit [31:0] BIT_ARRAY_PARAMETER = 32'b1,
+    parameter int INT_PARAMETER = 10,
+    parameter int unsigned INT_UNSIGNED_PARAMETER = 10,
+    parameter PACKAGE_PARAMETER = pa_Package::PARAMETER
+)(
+    input logic ck,
+    input logic arst,
+    output logic [31:0] data
+);
+
+localparam LPARAM_0 = EMPTY_PARAMETER;
+localparam LPARAM_1 = DEFINED_PARAMETER;
+localparam LPARAM_2 = BIT_PARAMETER;
+localparam LPARAM_3 = BIT_ARRAY_PARAMETER;
+localparam LPARAM_4 = INT_PARAMETER;
+localparam LPARAM_5 = INT_UNSIGNED_PARAMETER;
+localparam LPARAM_6 = PACKAGE_PARAMETER;
+
+logic [31:0] currentData;
+logic [31:0] nextData;
+
+assign data = currentData;
+
+always_ff @(posedge ck or arst) begin
+    if(arst) begin
+        currentData <= '0;
+    end else begin
+        currentData <= nextData;
+    end
+end
+
+portTest u_test (
+    .dataIn     (currentData),
+    .dataOut    (nextData)
+);
+
+endmodule
+


### PR DESCRIPTION
### Main Changes
These changes attempt to fix some bugs related to the DefinitionProvider not being able to find some parameters and ports:

* Fix usage of `results.concat` for ports and ensure all symbol lookups resolve before returning the results.
* Make the parameter name match correctly. In some cases the datatype was matched as the name. Also enable more datatypes for parameters e.g. `int unsigned`. 
* Fix definition lookup of symbols in packages
* Add tests

*See extended commit messages for more details.*

### Results after changes
***Definition of port:***

![image](https://github.com/eirikpre/VSCode-SystemVerilog/assets/3136092/9a6073fd-8249-43d7-b0ad-854d75dccb51)

***Definition of typed parameter:***

![image](https://github.com/eirikpre/VSCode-SystemVerilog/assets/3136092/29fef81f-c653-4963-9803-a152c07db44b)

***Definition of parameter defined in package:***

![image](https://github.com/eirikpre/VSCode-SystemVerilog/assets/3136092/04fa54e4-f9d2-4253-bf83-f0c98ee93842)
