### PR TITLE
Fix/parser module with import

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,6 +16,7 @@ export class SystemVerilogParser {
             /(?:automatic\s+)?/,
             ')',
             /(?<name>\w+)/,
+            /(?<import>\s*import\s*\w+::[\w*]+;)?/,
             /(?<params>\s*#\s*\([\w\W]*?\))?/,
             /(?<ports>\s*\([\W\w]*?\))?/,
             /\s*;/,

--- a/src/providers/ModuleInstantiator.ts
+++ b/src/providers/ModuleInstantiator.ts
@@ -121,7 +121,7 @@ function isModuleParameterized(symbol: string, container: string): boolean {
     // Get only indexes related to module header
     const subkeys = keys.slice(
         0,
-        keys.findIndex((element) => element.includes(";") && !element.includes("::"))
+        keys.findIndex((element) => element.includes(';') && !element.includes('::'))
     );
 
     if (subkeys[0] === symbol && subkeys.find((element) => element === '#(')) {

--- a/src/providers/ModuleInstantiator.ts
+++ b/src/providers/ModuleInstantiator.ts
@@ -119,7 +119,10 @@ function isModuleParameterized(symbol: string, container: string): boolean {
     }
 
     // Get only indexes related to module header
-    const subkeys = keys.slice(0, keys.findIndex((element) => element.includes(";") && !element.includes("::")))
+    const subkeys = keys.slice(
+        0,
+        keys.findIndex((element) => element.includes(";") && !element.includes("::"))
+    );
 
     if (subkeys[0] === symbol && subkeys.find((element) => element === '#(')) {
         return true;

--- a/src/providers/ModuleInstantiator.ts
+++ b/src/providers/ModuleInstantiator.ts
@@ -108,7 +108,7 @@ function isModuleParameterized(symbol: string, container: string): boolean {
     // Remove new lines
     container = container.replace(/\r\n|\n|\r/g, ' ');
     // Surround '#(' with space
-    container = container.replace(/#\(/g, ' #( ');
+    container = container.replace(/#\s*\(/g, ' #( ');
     // Replace multiple white spaces with a single whitespace
     container = container.replace(/\t+/g, ' ');
     container = container.replace(/  +/g, ' ');
@@ -118,7 +118,10 @@ function isModuleParameterized(symbol: string, container: string): boolean {
         return false;
     }
 
-    if (keys[0] === symbol && keys[1] === '#(') {
+    // Get only indexes related to module header
+    const subkeys = keys.slice(0, keys.findIndex((element) => element.includes(";") && !element.includes("::")))
+
+    if (subkeys[0] === symbol && subkeys.find((element) => element === '#(')) {
         return true;
     }
 

--- a/src/test/ModuleInstantiator.test.ts
+++ b/src/test/ModuleInstantiator.test.ts
@@ -206,7 +206,7 @@ suite('ModuleInstantiator Tests', () => {
 
         let fullRange = null;
         // Range of the module in the document
-        fullRange = new vscode.Range(new vscode.Position(300, 6), new vscode.Position(324, 0));
+        fullRange = new vscode.Range(new vscode.Position(301, 6), new vscode.Position(324, 0));
 
         let container = document.getText(fullRange).replace(/^\s+|\s+$/g, '');
 
@@ -239,6 +239,47 @@ suite('ModuleInstantiator Tests', () => {
 
         compareInstantiation('azzer', container, instance);
     });
+
+    test('test #10: formatInstance without parameters and with import', async () => {
+        let uri = vscode.Uri.file(path.join(__dirname, testFolderLocation, 'test-files', 'ModuleInstantiator.test.1.v')); // prettier-ignore
+        let document = await vscode.workspace.openTextDocument(uri);
+
+        // Range of the module in the document
+        let fullRange = null;
+        fullRange = new vscode.Range(new vscode.Position(358, 6), new vscode.Position(392, 0));
+
+        const container = document.getText(fullRange).replace(/^\s+|\s+$/g, '');
+        uri = vscode.Uri.file(path.join(__dirname, testFolderLocation, 'test-files', 'ModuleInstantiator.test.2.v'));
+        document = await vscode.workspace.openTextDocument(uri);
+        fullRange = new vscode.Range(new vscode.Position(168, 0), new vscode.Position(179, 0));
+
+        let instance = document.getText(fullRange);
+
+        compareInstantiation('abber', container, instance);
+    });
+
+    test('test #11: formatInstance with parameters and specific import', async () => {
+        let uri = vscode.Uri.file(path.join(__dirname, testFolderLocation, 'test-files', 'ModuleInstantiator.test.1.v')); // prettier-ignore
+        let document = await vscode.workspace.openTextDocument(uri);
+
+        let fullRange = null;
+        // Range of the module in the document
+        fullRange = new vscode.Range(new vscode.Position(395, 6), new vscode.Position(431, 0));
+
+        let container = document.getText(fullRange).replace(/^\s+|\s+$/g, '');
+
+        console.log("Container \n\r"+container);
+
+        uri = vscode.Uri.file(path.join(__dirname, testFolderLocation, 'test-files', 'ModuleInstantiator.test.2.v'));
+        document = await vscode.workspace.openTextDocument(uri);
+
+        fullRange = new vscode.Range(new vscode.Position(184, 0), new vscode.Position(198, 0));
+
+        let instance = document.getText(fullRange);
+
+        compareInstantiation('affer', container, instance);
+    });
+
 });
 
 function compareInstantiation(instance_name, container_name, expected): void {

--- a/src/test/ModuleInstantiator.test.ts
+++ b/src/test/ModuleInstantiator.test.ts
@@ -268,7 +268,7 @@ suite('ModuleInstantiator Tests', () => {
 
         let container = document.getText(fullRange).replace(/^\s+|\s+$/g, '');
 
-        console.log("Container \n\r"+container);
+        console.log('Container \n\r' + container);
 
         uri = vscode.Uri.file(path.join(__dirname, testFolderLocation, 'test-files', 'ModuleInstantiator.test.2.v'));
         document = await vscode.workspace.openTextDocument(uri);
@@ -279,7 +279,6 @@ suite('ModuleInstantiator Tests', () => {
 
         compareInstantiation('affer', container, instance);
     });
-
 });
 
 function compareInstantiation(instance_name, container_name, expected): void {

--- a/src/test/indexer_map.test.ts
+++ b/src/test/indexer_map.test.ts
@@ -17,7 +17,7 @@ let symbols: Map<string, Array<SystemVerilogSymbol>>;
 const testFolderLocation = '../../src/test';
 
 const uri = Uri.file(path.join(__dirname, testFolderLocation, 'test-files', 'ModuleInstantiator.test.1.v'));
-const documentSymbols = ['adder', 'bar', 'akker', 'accer', 'anner', 'atter', 'apper', 'golden'];
+const documentSymbols = ['adder', 'bar', 'akker', 'accer', 'anner', 'atter', 'apper', 'golden', 'abber', 'affer'];
 
 const nonSVUri = Uri.file(path.join(__dirname, testFolderLocation, 'test-files', 'foo.txt'));
 
@@ -31,10 +31,10 @@ suite('indexer_map Tests', () => {
         assert.strictEqual(symbols.size, 4);
         let count = await indexer.addDocumentSymbols(sVDocument, symbols);
 
-        assert.strictEqual(count, 10);
+        assert.strictEqual(count, 12);
         assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(symbols.get(uri.fsPath).length, 10);
-        assert.strictEqual(getSymbolsCount(), 23);
+        assert.strictEqual(symbols.get(uri.fsPath).length, 12);
+        assert.strictEqual(getSymbolsCount(), 25);
 
         documentSymbols.forEach((symbolName) => {
             if (!symbolExists(symbolName)) {
@@ -47,28 +47,28 @@ suite('indexer_map Tests', () => {
         assert.strictEqual(count, 0);
         assert.strictEqual(symbols.size, 5);
         assert.strictEqual(symbols.get(nonSVUri.fsPath), undefined);
-        assert.strictEqual(getSymbolsCount(), 23);
+        assert.strictEqual(getSymbolsCount(), 25);
 
         // undefined/null document
         count = await indexer.addDocumentSymbols(undefined, symbols);
         assert.strictEqual(count, 0);
         assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 23);
+        assert.strictEqual(getSymbolsCount(), 25);
 
         count = await indexer.addDocumentSymbols(sVDocument, undefined);
         assert.strictEqual(count, 0);
         assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 23);
+        assert.strictEqual(getSymbolsCount(), 25);
 
         count = await indexer.addDocumentSymbols(undefined, undefined);
         assert.strictEqual(count, 0);
         assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 23);
+        assert.strictEqual(getSymbolsCount(), 25);
 
         count = await indexer.addDocumentSymbols(null, symbols);
         assert.strictEqual(count, 0);
         assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 23);
+        assert.strictEqual(getSymbolsCount(), 25);
     });
 
     test('test #2: removeDocumentSymbols', async () => {
@@ -80,9 +80,9 @@ suite('indexer_map Tests', () => {
         assert.strictEqual(symbols.size, 4);
         let count = await indexer.addDocumentSymbols(sVDocument, symbols);
 
-        assert.strictEqual(count, 10);
+        assert.strictEqual(count, 12);
         assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 23);
+        assert.strictEqual(getSymbolsCount(), 25);
 
         count = indexer.removeDocumentSymbols(sVDocument.uri.fsPath, symbols);
 
@@ -92,7 +92,7 @@ suite('indexer_map Tests', () => {
             }
         });
 
-        assert.strictEqual(count, -10);
+        assert.strictEqual(count, -12);
         assert.strictEqual(symbols.size, 4);
         assert.strictEqual(getSymbolsCount(), 13);
 

--- a/src/test/test-files/ModuleInstantiator.test.1.v
+++ b/src/test/test-files/ModuleInstantiator.test.1.v
@@ -351,3 +351,80 @@ module azzer #(parameter SIZE = (2*1)+1,
   assign c = tmp_c;
 
 endmodule
+
+// -------------------------------------------------------
+// -- Example without parameters and with import
+// -------------------------------------------------------
+
+module abber import pa_Package::*; (
+  input 	     clk,
+  input 	     reset,
+  input  [3:0] a,
+  // keep this single comment
+  input  [3:0] b,
+  /* multiline comment should
+  be kept*/
+  input        valid,
+  output [6:0] c
+  );
+
+  reg [6:0] tmp_c;
+
+  //Reset
+  always_ff @(posedge reset)
+    tmp_c <= pa_adder::RV_C;
+
+  `ifdef VERBOSE_RESET
+    always @(posedge reset) begin
+      wait(posedge reset);
+      $display("Reset asserted!")
+    end
+  `endif
+
+  // Waddition operation
+  always @(posedge clk)
+    if(valid) tmp_c <= a + b;
+
+  assign c = tmp_c;
+
+endmodule
+
+// -------------------------------------------------------
+// -- Example with parameters and specific import
+// -------------------------------------------------------
+
+module affer import pa_Package::PARAMETER1; #(
+  parameter     SIZE = PARAMETER1,
+  parameter     SIZE_TWO
+)(
+  input 	     clk,
+  input 	     reset,
+  input  [3:0] a,
+  // keep this single comment
+  input  [3:0] b,
+  /* multiline comment should
+  be kept*/
+  input        valid,
+  output [6:0] c
+  );
+
+  reg [6:0] tmp_c;
+
+  //Reset
+  always_ff @(posedge reset)
+    tmp_c <= pa_adder::RV_C;
+
+  `ifdef VERBOSE_RESET
+    always @(posedge reset) begin
+      wait(posedge reset);
+      $display("Reset asserted!")
+    end
+  `endif
+
+  // Waddition operation
+  always @(posedge clk)
+    if(valid) tmp_c <= a + b;
+
+  assign c = tmp_c;
+
+endmodule

--- a/src/test/test-files/ModuleInstantiator.test.2.v
+++ b/src/test/test-files/ModuleInstantiator.test.2.v
@@ -163,5 +163,41 @@ azzer #(
 );
 
 // -------------------------------------------------------
+// -- Example without parameters and with import
+// -------------------------------------------------------
+
+abber u_abber (
+  .clk      (clk),
+  .reset    (reset),
+  .a        (a),
+  // keep this single comment
+  .b        (b),
+  /* multiline comment should
+  be kept*/
+  .valid    (valid),
+  .c        (c)
+);
+
+// -------------------------------------------------------
+// -- Example with parameters and specific import
+// -------------------------------------------------------
+
+affer #(
+  .SIZE        (PARAMETER1),
+  .SIZE_TWO    (SIZE_TWO)
+) u_affer (
+  .clk         (clk),
+  .reset       (reset),
+  .a           (a),
+  // keep this single comment
+  .b           (b),
+  /* multiline comment should
+  be kept*/
+  .valid       (valid),
+  .c           (c)
+);
+
+
+// -------------------------------------------------------
 // -- End file
 // -------------------------------------------------------


### PR DESCRIPTION
### Evolution reason
Due to local import in module header, block declaration was not detected. So auto-instantiation was not possible for these blocks.

### Update
#### Functional
- Change regex for block declaration
- Change the checks for parameterized module

#### Test
- Add test # 10 and # 11 for ModuleInstantiator test
- Update test values for indexer_map tests