### PR TITLE
Improved reference provider worker

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,10 +8,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: '20'
       - run: npm ci
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,39 +13,43 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-    name: Run extension tests (Node.js 16 on ${{ matrix.os }})
+    name: Run extension tests (Node 20 on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone vscode-systemverilog
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         id: node
         with:
-          node-version: '16'
+          node-version: '20'
       - name: Install NPM dependencies
-        run: npm ci --production=false --unsafe-perm
+        run: npm ci --unsafe-perm
       - name: Compile extension
         run: npm run compile
       - name: Create bundle
         run: npm run webpack
       - name: Run headless tests and collect coverage
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: npm run coverage
           working-directory: ./
           options: ''
       - name: Verify files
         if: runner.os == 'Linux'
-        run: ls -l dist/client/extension.js dist/server/server.js coverage/index.html
+        run: ls -l dist/client/extension.js dist/client/indexer-worker.js dist/server/server.js coverage/index.html
   qa:
     name: Run quality checks
     runs-on: ubuntu-latest
     steps:
       - name: Clone vscode-systemverilog
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Install NPM dependencies
-        run: npm ci --production=false --unsafe-perm
+        run: npm ci --unsafe-perm
       - name: Compile ANTLR
         run: npm run compile:antlr4ts
       - name: Run ESLint

--- a/build/client.webpack.config.js
+++ b/build/client.webpack.config.js
@@ -4,10 +4,11 @@ const withDefaults = require('./shared.webpack.config');
 module.exports = withDefaults({
     context: path.join(__dirname),
     entry: {
-        extension: '../src/extension.ts'
+        extension: '../src/extension.ts',
+        'indexer-worker': '../src/indexer-worker.ts'
     },
     output: {
-        filename: 'extension.js',
+        filename: '[name].js',
         path: path.join(__dirname, '..', 'dist', 'client')
     }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/glob": "^7.2.0",
                 "@types/mocha": "^9.1.0",
-                "@types/node": "^14.18.12",
+                "@types/node": "^20.11.0",
                 "@types/vscode": "^1.61.0",
                 "@typescript-eslint/eslint-plugin": "^5.14.0",
                 "@typescript-eslint/parser": "^5.14.0",
@@ -46,7 +46,7 @@
                 "source-map-support": "^0.5.21",
                 "ts-loader": "^9.2.8",
                 "ts-node": "^10.7.0",
-                "typescript": "^4.6.2",
+                "typescript": "^5.4.0",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^4.9.2"
             },
@@ -1056,16 +1056,21 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "14.18.12",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-            "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
-            "dev": true
+            "version": "20.19.41",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+            "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
         },
         "node_modules/@types/vscode": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
-            "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
-            "dev": true
+            "version": "1.120.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+            "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "5.14.0",
@@ -5765,16 +5770,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-            "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/unbox-primitive": {
@@ -5791,6 +5797,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.0",
@@ -7173,15 +7186,18 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.18.12",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-            "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
-            "dev": true
+            "version": "20.19.41",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+            "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~6.21.0"
+            }
         },
         "@types/vscode": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
-            "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
+            "version": "1.120.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+            "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
@@ -10640,9 +10656,9 @@
             }
         },
         "typescript": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-            "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true
         },
         "unbox-primitive": {
@@ -10656,6 +10672,12 @@
                 "has-symbols": "^1.0.2",
                 "which-boxed-primitive": "^1.0.2"
             }
+        },
+        "undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true
         },
         "update-browserslist-db": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -288,11 +288,6 @@
                         "default": false,
                         "description": "Disable automatic indexing when opening a folder or workspace."
                     },
-                    "systemverilog.parallelProcessing": {
-                        "type": "integer",
-                        "default": 10,
-                        "description": "The number of files the extension should attempt to process in parallel. Processing consist of opening found files and perform matching to find symbols."
-                    },
                     "systemverilog.includeIndexing": {
                         "type": "array",
                         "default": [
@@ -660,7 +655,7 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.0",
-        "@types/node": "^14.18.12",
+        "@types/node": "^20.11.0",
         "@types/vscode": "^1.61.0",
         "@typescript-eslint/eslint-plugin": "^5.14.0",
         "@typescript-eslint/parser": "^5.14.0",
@@ -682,7 +677,7 @@
         "source-map-support": "^0.5.21",
         "ts-loader": "^9.2.8",
         "ts-node": "^10.7.0",
-        "typescript": "^4.6.2",
+        "typescript": "^5.4.0",
         "webpack": "^5.94.0",
         "webpack-cli": "^4.9.2"
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
-import { workspace, window, languages, commands, StatusBarAlignment, DocumentSelector, ExtensionContext, ProgressLocation, Location, Range, Uri } from 'vscode'; // prettier-ignore
+import { workspace, window, languages, commands, StatusBarAlignment, DocumentSelector, ExtensionContext, ProgressLocation, Uri } from 'vscode'; // prettier-ignore
 import { LanguageClient, ServerOptions, TransportKind, LanguageClientOptions } from 'vscode-languageclient/node';
 import * as path from 'path';
+import * as fs from 'fs';
 import { SystemVerilogDefinitionProvider } from './providers/DefinitionProvider';
 import { SystemVerilogDocumentSymbolProvider } from './providers/DocumentSymbolProvider';
 import { SystemVerilogFormatProvider } from './providers/FormatProvider';
@@ -8,9 +9,8 @@ import { SystemVerilogHoverProvider } from './providers/HoverProvider';
 import { SystemVerilogWorkspaceSymbolProvider } from './providers/WorkspaceSymbolProvider';
 import { SystemVerilogReferenceProvider } from './providers/ReferenceProvider';
 import { SystemVerilogModuleInstantiator } from './providers/ModuleInstantiator';
-import { SystemVerilogParser } from './parser';
 import { SystemVerilogIndexer } from './indexer';
-import { SystemVerilogSymbol } from './symbol';
+import { IndexerClient } from './utils/indexer-client';
 
 // The LSP's client
 let client: LanguageClient;
@@ -28,23 +28,20 @@ const selector: DocumentSelector = [
 ];
 
 let indexer: SystemVerilogIndexer | undefined = undefined;
-let saveIndexTimeout: NodeJS.Timeout | undefined;
+let indexerClient: IndexerClient | undefined = undefined;
 
-function queuedSaveIndex(context: ExtensionContext) {
-    if (saveIndexTimeout !== undefined) {
-        clearTimeout(saveIndexTimeout);
+function resolveStorageDir(context: ExtensionContext): string {
+    const base = context.storageUri || context.globalStorageUri;
+    // If we have no workspace storage, fall back to a transient OS temp dir.
+    // The cache simply won't persist across restarts in that case.
+    const base_fs = base ? base.fsPath : path.join(require('os').tmpdir(), 'sv-index-transient');
+    const dir = path.join(base_fs, 'sv-index');
+    try {
+        fs.mkdirSync(dir, { recursive: true });
+    } catch {
+        /* mkdir is best-effort */
     }
-
-    saveIndexTimeout = setTimeout(function () {
-        saveIndex(context);
-    }, 10000);
-}
-
-function saveIndex(context: ExtensionContext): void {
-    saveIndexTimeout = undefined;
-
-    const syms = [...indexer.symbols];
-    context.workspaceState.update('symbols', syms);
+    return dir;
 }
 
 export function activate(context: ExtensionContext) {
@@ -57,12 +54,26 @@ export function activate(context: ExtensionContext) {
     statusBar.show();
     statusBar.command = 'systemverilog.build_index';
 
+    // One-time cleanup of the legacy monolithic workspaceState blob.
+    if (context.workspaceState.get('symbols') !== undefined) {
+        context.workspaceState.update('symbols', undefined);
+    }
+
+    // Start the indexer worker
+    const storageDir = resolveStorageDir(context);
+    indexerClient = new IndexerClient({
+        storageDir,
+        workerPath: context.asAbsolutePath(path.join('dist', 'client', 'indexer-worker.js')),
+        onCrash: (err) => {
+            outputChannel.appendLine(`SystemVerilog: indexer worker crashed: ${err.stack || err.message}`);
+        }
+    });
+
     // Back-end Classes
-    const parser = new SystemVerilogParser();
-    indexer = new SystemVerilogIndexer(statusBar, parser, outputChannel);
+    indexer = new SystemVerilogIndexer(statusBar, outputChannel, indexerClient);
 
     // Providers
-    const docProvider = new SystemVerilogDocumentSymbolProvider(parser, indexer);
+    const docProvider = new SystemVerilogDocumentSymbolProvider(indexer);
     const symProvider = new SystemVerilogWorkspaceSymbolProvider(indexer);
     const defProvider = new SystemVerilogDefinitionProvider();
     const hoverProvider = new SystemVerilogHoverProvider();
@@ -80,7 +91,7 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(languages.registerReferenceProvider(selector, referenceProvider));
 
     const buildHandler = () => {
-        indexer.build_index().then((_) => queuedSaveIndex(context));
+        indexer.build_index();
     };
     const instantiateHandler = () => {
         moduleInstantiator.instantiateModule();
@@ -94,83 +105,48 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(
         workspace.onDidSaveTextDocument((doc) => {
             indexer.onChange(doc);
-            queuedSaveIndex(context);
-        })
-    );
-    context.subscriptions.push(
-        window.onDidChangeActiveTextEditor((editor) => {
-            if (editor !== undefined) {
-                indexer.onChange(editor.document);
-                queuedSaveIndex(context);
-            }
         })
     );
     const watcher = workspace.createFileSystemWatcher('**/*.{sv,v,svh,vh}', false, false, false);
     context.subscriptions.push(
         watcher.onDidCreate((uri) => {
             indexer.onCreate(uri);
-            queuedSaveIndex(context);
         })
     );
     context.subscriptions.push(
         watcher.onDidDelete((uri) => {
             indexer.onDelete(uri);
-            queuedSaveIndex(context);
         })
     );
     context.subscriptions.push(
         watcher.onDidChange((uri) => {
-            indexer.onDelete(uri);
-            queuedSaveIndex(context);
+            // Re-index the changed file (previously this incorrectly called
+            // onDelete, which removed the file's symbols without re-parsing).
+            indexer.onCreate(uri);
         })
     );
     context.subscriptions.push(watcher);
 
-    const settings = workspace.getConfiguration();
-    try {
-        loadIndex();
-    } catch (error) {
-        if (settings.get('systemverilog.disableIndexing')) {
-            statusBar.text = 'SystemVerilog: Indexing disabled on boot';
-        } else {
-            commands.executeCommand('systemverilog.build_index');
+    indexerClient.whenReady().then(
+        async () => {
+            const settings = workspace.getConfiguration();
+            const cached = await indexerClient.count();
+            if (cached > 0) {
+                indexer.symbolsCount = cached;
+                statusBar.text = `SystemVerilog: ${cached} indexed objects`;
+                // Background revalidation will pick up any stale files via the
+                // mtime gate the next time they are saved or opened.
+            } else if (!settings.get('systemverilog.disableIndexing')) {
+                commands.executeCommand('systemverilog.build_index');
+            } else {
+                statusBar.text = 'SystemVerilog: Indexing disabled on boot';
+            }
+        },
+        (err) => {
+            outputChannel.appendLine(`SystemVerilog: indexer init failed: ${err.stack || err.message}`);
+            statusBar.text = 'SystemVerilog: Indexer failed to start';
         }
-    }
-
-    function loadIndex(): void {
-        const symbols: Array<any> = context.workspaceState.get('symbols');
-        let numSymbols = 0;
-        if (symbols) {
-            symbols.forEach((entry) => {
-                // Hack because typecasting didn't work
-                const syms: SystemVerilogSymbol[] = new Array<SystemVerilogSymbol>();
-                entry[1].forEach((s) => {
-                    syms.push(
-                        new SystemVerilogSymbol(
-                            s.name,
-                            s.kind,
-                            s.containerName,
-                            new Location(
-                                Uri.file(entry[0]),
-                                new Range(
-                                    s.location.range[0].line,
-                                    s.location.range[0].character,
-                                    s.location.range[1].line,
-                                    s.location.range[1].character
-                                )
-                            )
-                        )
-                    );
-                    numSymbols += 1;
-                });
-                indexer.symbols.set(entry[0], syms);
-                indexer.symbolsCount = numSymbols;
-            });
-            statusBar.text = `SystemVerilog: ${numSymbols} indexed objects`;
-        } else {
-            throw new Error('Could not load index');
-        }
-    }
+    );
 
     /**
         Sends a notification to the LSP to compile the opened document.
@@ -232,9 +208,6 @@ export function activate(context: ExtensionContext) {
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         documentSelector: selector as string[]
-        // synchronize: {
-        //     fileEvents: workspace.createFileSystemWatcher(indexer.globPattern)
-        // }
     };
 
     // Create the language client and start the client
@@ -262,12 +235,14 @@ export function activate(context: ExtensionContext) {
     });
 }
 
-export function deactivate(context: ExtensionContext): Thenable<void> | undefined {
-    if (!client) {
-        return undefined;
+export function deactivate(_context: ExtensionContext): Thenable<void> | undefined {
+    const stops: Promise<unknown>[] = [];
+    if (indexerClient) {
+        stops.push(indexerClient.dispose().catch(() => undefined));
+        indexerClient = undefined;
     }
-
-    queuedSaveIndex(context);
-
-    return client.stop();
+    if (client) {
+        stops.push(client.stop());
+    }
+    return Promise.all(stops).then(() => undefined);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { workspace, window, languages, commands, StatusBarAlignment, DocumentSelector, ExtensionContext, ProgressLocation, Uri } from 'vscode'; // prettier-ignore
+import { workspace, window, languages, commands, StatusBarAlignment, DocumentSelector, ExtensionContext, ProgressLocation } from 'vscode'; // prettier-ignore
 import { LanguageClient, ServerOptions, TransportKind, LanguageClientOptions } from 'vscode-languageclient/node';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -34,8 +34,8 @@ function resolveStorageDir(context: ExtensionContext): string {
     const base = context.storageUri || context.globalStorageUri;
     // If we have no workspace storage, fall back to a transient OS temp dir.
     // The cache simply won't persist across restarts in that case.
-    const base_fs = base ? base.fsPath : path.join(require('os').tmpdir(), 'sv-index-transient');
-    const dir = path.join(base_fs, 'sv-index');
+    const baseFs = base ? base.fsPath : path.join(require('os').tmpdir(), 'sv-index-transient');
+    const dir = path.join(baseFs, 'sv-index');
     try {
         fs.mkdirSync(dir, { recursive: true });
     } catch {

--- a/src/indexer-worker.ts
+++ b/src/indexer-worker.ts
@@ -1,0 +1,387 @@
+import { parentPort } from 'worker_threads';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SystemVerilogParser, StringSource } from './parser-core';
+import { ParseAndUpsertParams, ParseTextParams, SymbolWire, UpsertParams } from './wire-types';
+
+// Storage layout (under <storageDir>):
+//   manifest.json                   { version, files: { <fspath>: FileMeta } }
+//   shards/<aa>/<sha1>.json         { path, mtimeMs, size, parsedAt, symbols: [...] }
+//
+// Why per-file shards: each save rewrites at most one small file plus the
+// (debounced) manifest. There is no central blob to keep coherent.
+
+const STORAGE_VERSION = 1;
+const MANIFEST_DEBOUNCE_MS = 250;
+
+const parser = new SystemVerilogParser();
+
+type FileMeta = { mtimeMs: number; size: number; parsedAt: number };
+
+export type Req = { id: number; method: string; params?: any };
+export type Res =
+    | { id: number; ok: true; result: any }
+    | { id: number; ok: false; error: string };
+
+const state = {
+    storageDir: '' as string,
+    shardsDir: '' as string,
+    manifestPath: '' as string,
+    files: new Map<string, FileMeta>(),
+    byFile: new Map<string, SymbolWire[]>(),
+    byName: new Map<string, SymbolWire[]>(),
+    byNameLower: new Map<string, SymbolWire[]>(),
+    byType: new Map<string, SymbolWire[]>(),
+    total: 0,
+    manifestDirty: false,
+    manifestTimer: null as NodeJS.Timeout | null
+};
+
+function shardPathFor(fspath: string): string {
+    const h = crypto.createHash('sha1').update(fspath).digest('hex');
+    return path.join(state.shardsDir, h.slice(0, 2), `${h}.json`);
+}
+
+function pushTo<K>(map: Map<K, SymbolWire[]>, key: K, sym: SymbolWire): void {
+    let arr = map.get(key);
+    if (!arr) {
+        arr = [];
+        map.set(key, arr);
+    }
+    arr.push(sym);
+}
+
+function removeAllByFile(fspath: string): void {
+    const syms = state.byFile.get(fspath);
+    if (!syms) return;
+    // Build the set of unique keys this file touches first, so each map is
+    // filtered at most once per key. Without this, popular identifiers (e.g.
+    // "clk" appearing thousands of times in one file) trigger one O(N)
+    // filter per occurrence — quadratic on file size in the worst case.
+    const names = new Set<string>();
+    const namesLower = new Set<string>();
+    const types = new Set<string>();
+    for (const s of syms) {
+        names.add(s.name);
+        namesLower.add(s.name.toLowerCase());
+        types.add(s.type);
+    }
+    for (const k of names) pruneKey(state.byName, k, fspath);
+    for (const k of namesLower) pruneKey(state.byNameLower, k, fspath);
+    for (const k of types) pruneKey(state.byType, k, fspath);
+    state.byFile.delete(fspath);
+    state.total -= syms.length;
+}
+
+function pruneKey(map: Map<string, SymbolWire[]>, key: string, fspath: string): void {
+    const arr = map.get(key);
+    if (!arr) return;
+    const next = arr.filter((s) => s.file !== fspath);
+    if (next.length === 0) map.delete(key);
+    else map.set(key, next);
+}
+
+function indexSymbols(fspath: string, wireSyms: SymbolWire[]): void {
+    state.byFile.set(fspath, wireSyms);
+    for (const s of wireSyms) {
+        pushTo(state.byName, s.name, s);
+        pushTo(state.byNameLower, s.name.toLowerCase(), s);
+        pushTo(state.byType, s.type, s);
+    }
+    state.total += wireSyms.length;
+}
+
+function ensureDirs(): void {
+    fs.mkdirSync(state.shardsDir, { recursive: true });
+}
+
+function readJsonSafe(filePath: string): any | null {
+    try {
+        const data = fs.readFileSync(filePath, 'utf8');
+        return JSON.parse(data);
+    } catch {
+        return null;
+    }
+}
+
+function writeFileAtomic(target: string, data: string): void {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    fs.writeFileSync(tmp, data);
+    fs.renameSync(tmp, target);
+}
+
+function writeManifestNow(): void {
+    if (state.manifestTimer) {
+        clearTimeout(state.manifestTimer);
+        state.manifestTimer = null;
+    }
+    if (!state.manifestDirty) return;
+    state.manifestDirty = false;
+    const out = { version: STORAGE_VERSION, files: Object.fromEntries(state.files) };
+    writeFileAtomic(state.manifestPath, JSON.stringify(out));
+}
+
+function scheduleManifestWrite(): void {
+    state.manifestDirty = true;
+    if (state.manifestTimer) return;
+    state.manifestTimer = setTimeout(() => {
+        state.manifestTimer = null;
+        try {
+            writeManifestNow();
+        } catch (err) {
+            // Surface via the next RPC; for now log to stderr.
+            console.error('manifest write failed:', err);
+        }
+    }, MANIFEST_DEBOUNCE_MS);
+}
+
+function loadFromDisk(): void {
+    const manifest = readJsonSafe(state.manifestPath);
+    if (!manifest || manifest.version !== STORAGE_VERSION || typeof manifest.files !== 'object') {
+        // Cold start (no manifest) or version mismatch; wipe shards.
+        if (fs.existsSync(state.shardsDir)) {
+            fs.rmSync(state.shardsDir, { recursive: true, force: true });
+        }
+        ensureDirs();
+        if (fs.existsSync(state.manifestPath)) fs.unlinkSync(state.manifestPath);
+        return;
+    }
+
+    for (const [fspath, meta] of Object.entries(manifest.files as Record<string, FileMeta>)) {
+        const shard = readJsonSafe(shardPathFor(fspath));
+        if (!shard || !Array.isArray(shard.symbols)) {
+            // Shard missing or corrupt — drop this entry; it'll be re-parsed.
+            continue;
+        }
+        state.files.set(fspath, meta);
+        const wireSyms: SymbolWire[] = shard.symbols.map((s: Omit<SymbolWire, 'file'>) => ({
+            ...s,
+            file: fspath
+        }));
+        indexSymbols(fspath, wireSyms);
+    }
+}
+
+function applyExclude<T extends { type: string }>(rows: T[], excludeTypes?: string[]): T[] {
+    if (!excludeTypes || excludeTypes.length === 0) return rows;
+    const ex = new Set(excludeTypes);
+    return rows.filter((r) => !ex.has(r.type));
+}
+
+function applyUpsert(
+    fspath: string,
+    mtimeMs: number,
+    size: number,
+    symbols: Array<Omit<SymbolWire, 'file'>>
+): void {
+    const parsedAt = Date.now();
+    const wireSyms: SymbolWire[] = symbols.map((s) => ({ ...s, file: fspath }));
+    // Write the shard first; if the disk write fails we leave state untouched.
+    const shard = { path: fspath, mtimeMs, size, parsedAt, symbols };
+    writeFileAtomic(shardPathFor(fspath), JSON.stringify(shard));
+
+    removeAllByFile(fspath);
+    indexSymbols(fspath, wireSyms);
+    state.files.set(fspath, { mtimeMs, size, parsedAt });
+    scheduleManifestWrite();
+}
+
+const handlers: Record<string, (params: any) => any> = {
+    init({ storageDir }: { storageDir: string }) {
+        state.storageDir = storageDir;
+        state.shardsDir = path.join(storageDir, 'shards');
+        state.manifestPath = path.join(storageDir, 'manifest.json');
+        ensureDirs();
+        loadFromDisk();
+        return null;
+    },
+
+    upsertFile(params: UpsertParams) {
+        applyUpsert(params.path, params.mtimeMs, params.size, params.symbols);
+        return null;
+    },
+
+    /**
+     * Parse a file's text in the worker, then store the result. Avoids
+     * paying the parsing cost on the extension-host main thread, which is
+     * the main source of UI hitches during initial indexing.
+     */
+    parseAndUpsert(params: ParseAndUpsertParams): number {
+        const src = new StringSource(params.text, params.path);
+        const wireSyms = parser.parse(src, params.precision, params.maxDepth);
+        const stripped = wireSyms.map(({ file: _f, ...rest }) => rest);
+        applyUpsert(params.path, params.mtimeMs, params.size, stripped);
+        return wireSyms.length;
+    },
+
+    /**
+     * Parse a file's text and return the symbols WITHOUT touching the index.
+     * Used by providers (e.g. DocumentSymbolProvider) that need a result for
+     * a file they don't want to commit at the chosen precision — so the
+     * cached full-precision entry from initial indexing isn't lost.
+     */
+    parseText(params: ParseTextParams): SymbolWire[] {
+        const src = new StringSource(params.text, params.path);
+        return parser.parse(src, params.precision, params.maxDepth);
+    },
+
+    deleteFile({ path: fspath }: { path: string }) {
+        removeAllByFile(fspath);
+        state.files.delete(fspath);
+        const shard = shardPathFor(fspath);
+        if (fs.existsSync(shard)) {
+            try {
+                fs.unlinkSync(shard);
+            } catch {
+                /* swallow */
+            }
+        }
+        scheduleManifestWrite();
+        return null;
+    },
+
+    getFileMeta({ paths }: { paths: string[] }) {
+        const out: Record<string, { mtimeMs: number; size: number }> = {};
+        for (const p of paths) {
+            const m = state.files.get(p);
+            if (m) out[p] = { mtimeMs: m.mtimeMs, size: m.size };
+        }
+        return out;
+    },
+
+    getFileSymbols({ path: fspath, excludeTypes }: { path: string; excludeTypes?: string[] }) {
+        const rows = state.byFile.get(fspath) || [];
+        return applyExclude(rows, excludeTypes);
+    },
+
+    queryByName({
+        name,
+        excludeTypes,
+        limit
+    }: {
+        name: string;
+        excludeTypes?: string[];
+        limit?: number;
+    }) {
+        const rows = state.byName.get(name) || [];
+        const filtered = applyExclude(rows, excludeTypes);
+        return limit && filtered.length > limit ? filtered.slice(0, limit) : filtered;
+    },
+
+    queryFuzzy({
+        pattern,
+        excludeTypes,
+        limit
+    }: {
+        pattern: string;
+        excludeTypes?: string[];
+        limit?: number;
+    }) {
+        const lower = pattern.replace(/\s/g, '').toLowerCase();
+        const max = limit ?? 500;
+        if (lower.length === 0) {
+            // Empty pattern matches anything; return up to `limit` results.
+            const out: SymbolWire[] = [];
+            for (const arr of state.byNameLower.values()) {
+                for (const s of arr) {
+                    if (excludeTypes && excludeTypes.includes(s.type)) continue;
+                    out.push(s);
+                    if (out.length >= max) return out;
+                }
+            }
+            return out;
+        }
+        const re = new RegExp(`.*${lower.split('').join('.*')}.*`, 'i');
+        const ex = excludeTypes ? new Set(excludeTypes) : null;
+        const seen = new Set<string>();
+        const out: SymbolWire[] = [];
+        for (const [key, arr] of state.byNameLower) {
+            if (!re.test(key)) continue;
+            for (const s of arr) {
+                if (ex && ex.has(s.type)) continue;
+                const id = `${s.file}:${s.sl}:${s.sc}:${s.name}`;
+                if (seen.has(id)) continue;
+                seen.add(id);
+                out.push(s);
+                if (out.length >= max) return out;
+            }
+        }
+        return out;
+    },
+
+    getAllByType({ type, limit }: { type: string; limit?: number }) {
+        const rows = state.byType.get(type) || [];
+        return limit && rows.length > limit ? rows.slice(0, limit) : rows;
+    },
+
+    getMostRecent({ limit }: { limit: number }) {
+        // Build a parsedAt-desc ordering from `files` and walk byFile.
+        const entries = [...state.files.entries()].sort(
+            (a, b) => b[1].parsedAt - a[1].parsedAt
+        );
+        const out: SymbolWire[] = [];
+        for (const [fspath] of entries) {
+            const syms = state.byFile.get(fspath);
+            if (!syms) continue;
+            for (const s of syms) {
+                out.push(s);
+                if (out.length >= limit) return out;
+            }
+        }
+        return out;
+    },
+
+    clearAll() {
+        if (state.manifestTimer) {
+            clearTimeout(state.manifestTimer);
+            state.manifestTimer = null;
+        }
+        state.files.clear();
+        state.byFile.clear();
+        state.byName.clear();
+        state.byNameLower.clear();
+        state.byType.clear();
+        state.total = 0;
+        if (fs.existsSync(state.shardsDir)) {
+            fs.rmSync(state.shardsDir, { recursive: true, force: true });
+        }
+        if (fs.existsSync(state.manifestPath)) fs.unlinkSync(state.manifestPath);
+        ensureDirs();
+        return null;
+    },
+
+    count() {
+        return state.total;
+    },
+
+    flush() {
+        writeManifestNow();
+        return null;
+    }
+};
+
+export function dispatch(req: Req): Res {
+    try {
+        const h = handlers[req.method];
+        if (!h) return { id: req.id, ok: false, error: `Unknown method: ${req.method}` };
+        const result = h(req.params);
+        return { id: req.id, ok: true, result };
+    } catch (e: any) {
+        return { id: req.id, ok: false, error: e && e.stack ? e.stack : String(e) };
+    }
+}
+
+if (parentPort) {
+    parentPort.on('message', (req: Req) => {
+        parentPort!.postMessage(dispatch(req));
+    });
+    process.on('beforeExit', () => {
+        try {
+            writeManifestNow();
+        } catch {
+            /* swallow */
+        }
+    });
+}

--- a/src/indexer-worker.ts
+++ b/src/indexer-worker.ts
@@ -20,9 +20,7 @@ const parser = new SystemVerilogParser();
 type FileMeta = { mtimeMs: number; size: number; parsedAt: number };
 
 export type Req = { id: number; method: string; params?: any };
-export type Res =
-    | { id: number; ok: true; result: any }
-    | { id: number; ok: false; error: string };
+export type Res = { id: number; ok: true; result: any } | { id: number; ok: false; error: string };
 
 const state = {
     storageDir: '' as string,
@@ -170,12 +168,7 @@ function applyExclude<T extends { type: string }>(rows: T[], excludeTypes?: stri
     return rows.filter((r) => !ex.has(r.type));
 }
 
-function applyUpsert(
-    fspath: string,
-    mtimeMs: number,
-    size: number,
-    symbols: Array<Omit<SymbolWire, 'file'>>
-): void {
+function applyUpsert(fspath: string, mtimeMs: number, size: number, symbols: Array<Omit<SymbolWire, 'file'>>): void {
     const parsedAt = Date.now();
     const wireSyms: SymbolWire[] = symbols.map((s) => ({ ...s, file: fspath }));
     // Write the shard first; if the disk write fails we leave state untouched.
@@ -256,29 +249,13 @@ const handlers: Record<string, (params: any) => any> = {
         return applyExclude(rows, excludeTypes);
     },
 
-    queryByName({
-        name,
-        excludeTypes,
-        limit
-    }: {
-        name: string;
-        excludeTypes?: string[];
-        limit?: number;
-    }) {
+    queryByName({ name, excludeTypes, limit }: { name: string; excludeTypes?: string[]; limit?: number }) {
         const rows = state.byName.get(name) || [];
         const filtered = applyExclude(rows, excludeTypes);
         return limit && filtered.length > limit ? filtered.slice(0, limit) : filtered;
     },
 
-    queryFuzzy({
-        pattern,
-        excludeTypes,
-        limit
-    }: {
-        pattern: string;
-        excludeTypes?: string[];
-        limit?: number;
-    }) {
+    queryFuzzy({ pattern, excludeTypes, limit }: { pattern: string; excludeTypes?: string[]; limit?: number }) {
         const lower = pattern.replace(/\s/g, '').toLowerCase();
         const max = limit ?? 500;
         if (lower.length === 0) {
@@ -318,9 +295,7 @@ const handlers: Record<string, (params: any) => any> = {
 
     getMostRecent({ limit }: { limit: number }) {
         // Build a parsedAt-desc ordering from `files` and walk byFile.
-        const entries = [...state.files.entries()].sort(
-            (a, b) => b[1].parsedAt - a[1].parsedAt
-        );
+        const entries = [...state.files.entries()].sort((a, b) => b[1].parsedAt - a[1].parsedAt);
         const out: SymbolWire[] = [];
         for (const [fspath] of entries) {
             const syms = state.byFile.get(fspath);

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -79,7 +79,11 @@ export class SystemVerilogIndexer {
                     const total = uris.length;
                     let lastReportedPct = 0;
 
-                    for (let i = 0; i < total; i++) {
+                    // Yield to the event loop so VSCode can process UI events
+                    // and respond to other provider requests between files.
+                    const yieldToEventLoop = (): Promise<void> => new Promise<void>((resolve) => setImmediate(resolve));
+
+                    for (let i = 0; i < total; i += 1) {
                         if (token.isCancellationRequested) {
                             cancelled = true;
                             break;
@@ -87,10 +91,8 @@ export class SystemVerilogIndexer {
                         // eslint-disable-next-line no-await-in-loop
                         await this.processFile(uris[i], total);
 
-                        // Yield to the event loop so VSCode can process UI events
-                        // and respond to other provider requests between files.
                         // eslint-disable-next-line no-await-in-loop
-                        await new Promise<void>((resolve) => setImmediate(resolve));
+                        await yieldToEventLoop();
 
                         // Report progress at most every 1% to avoid notification spam.
                         const processed = i + 1;
@@ -184,7 +186,7 @@ export class SystemVerilogIndexer {
             const text = await fs.promises.readFile(uri.fsPath, 'utf8');
             // Cheap line-count: number of '\n' + 1. Avoids materialising a doc.
             let lineCount = 1;
-            for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) lineCount++;
+            for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) lineCount += 1;
             const precision = this.resolvePrecision(lineCount);
             const maxDepth = this.maxDepthForPrecision(precision);
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -1,26 +1,20 @@
 import { StatusBarItem, GlobPattern, window, ProgressLocation, workspace, TextDocument, Uri, OutputChannel } from 'vscode'; // prettier-ignore
 import { CancellationToken } from 'vscode-languageclient/node';
+import * as fs from 'fs';
 import * as glob from 'glob';
 import * as minimatch from 'minimatch';
-import { SystemVerilogParser } from './parser';
 import { isSystemVerilogDocument, isVerilogDocument, isVerilogAMSDocument } from './utils/client';
-import { SystemVerilogSymbol } from './symbol';
+import { IndexerClient } from './utils/indexer-client';
+import { SystemVerilogSymbol, wireToSymbol } from './symbol';
 
 export class SystemVerilogIndexer {
-    /*
-     * this.symbols: filePath => Array<SystemVerilogSymbol>
-     * each entry's key represents a file path,
-     * and the entry's value is a list of the symbols that exist in the file
-     */
-    public symbols: Map<string, Array<SystemVerilogSymbol>>;
+    public client: IndexerClient;
     public mostRecentSymbols: Array<SystemVerilogSymbol>;
     public building = false;
     public statusbar: StatusBarItem;
-    public parser: SystemVerilogParser;
     public symbolsCount: number = 0;
 
     public NUM_FILES: number = 250;
-    public parallelProcessing: number = 1;
     public filesGlob: string = undefined;
     public exclude: GlobPattern = undefined;
     public forceFastIndexing: Boolean = false;
@@ -29,25 +23,34 @@ export class SystemVerilogIndexer {
 
     public outputChannel: OutputChannel;
 
-    constructor(statusbar: StatusBarItem, parser: SystemVerilogParser, channel: OutputChannel) {
+    constructor(statusbar: StatusBarItem, channel: OutputChannel, client: IndexerClient) {
         this.statusbar = statusbar;
-        this.parser = parser;
         this.outputChannel = channel;
-        this.symbols = new Map<string, Array<SystemVerilogSymbol>>();
+        this.client = client;
     }
 
     public initialize() {
         const settings = workspace.getConfiguration();
-        this.parallelProcessing = settings.get('systemverilog.parallelProcessing');
         this.forceFastIndexing = settings.get('systemverilog.forceFastIndexing');
         this.maxLineCountIndexing = settings.get('systemverilog.maxLineCountIndexing');
         this.documentSymbolPrecision = settings.get('systemverilog.documentSymbolsPrecision');
     }
 
+    /** Resolves the parse precision for one file given the active settings. */
+    public resolvePrecision(lineCount: number): string {
+        if (this.forceFastIndexing) return 'fast';
+        if (lineCount > this.maxLineCountIndexing.valueOf()) return 'fast';
+        return this.documentSymbolPrecision;
+    }
+
+    public maxDepthForPrecision(precision: string): number {
+        return precision === 'full' || precision === 'full_no_references' ? 1 : 0;
+    }
+
     /**
         Scans the `workspace` for SystemVerilog and Verilog files,
-        Looks up all the `symbols` that it exist on the queried files,
-        and saves the symbols as `SystemVerilogSymbol` objects to `this.symbols`.
+        Looks up all the `symbols` that exist on the queried files,
+        and saves the symbols to the SQLite-backed index.
 
         @return status message when indexing is successful or failed with an error.
     */
@@ -64,28 +67,50 @@ export class SystemVerilogIndexer {
                     title: 'SystemVerilog Indexing...',
                     cancellable: true
                 },
-                async (_progress, token) => {
-                    if (!this.building) {
-                        this.building = true;
-                        this.symbols = new Map<string, Array<SystemVerilogSymbol>>();
-                        const uris: Uri[] = await this.find_files(token);
-                        console.time('build_index'); // eslint-disable-line no-console
-                        for (let filenr = 0; filenr < uris.length; filenr += this.parallelProcessing) {
-                            const subset = uris.slice(filenr, filenr + this.parallelProcessing);
-                            if (token.isCancellationRequested) {
-                                cancelled = true;
-                                break;
-                            }
-                            await Promise.all(subset.map((uri) => this.processFile(uri, uris.length))); // eslint-disable-line no-await-in-loop
-                        }
-                    } else {
+                async (progress, token) => {
+                    if (this.building) {
                         return Promise.reject();
                     }
+                    this.building = true;
+                    await this.client.clearAll();
+                    const uris: Uri[] = await this.find_files(token);
+                    console.time('build_index'); // eslint-disable-line no-console
+
+                    const total = uris.length;
+                    let lastReportedPct = 0;
+
+                    for (let i = 0; i < total; i++) {
+                        if (token.isCancellationRequested) {
+                            cancelled = true;
+                            break;
+                        }
+                        // eslint-disable-next-line no-await-in-loop
+                        await this.processFile(uris[i], total);
+
+                        // Yield to the event loop so VSCode can process UI events
+                        // and respond to other provider requests between files.
+                        // eslint-disable-next-line no-await-in-loop
+                        await new Promise<void>((resolve) => setImmediate(resolve));
+
+                        // Report progress at most every 1% to avoid notification spam.
+                        const processed = i + 1;
+                        const pct = Math.floor((processed / total) * 100);
+                        if (pct > lastReportedPct) {
+                            progress.report({
+                                increment: pct - lastReportedPct,
+                                message: `${processed}/${total} files`
+                            });
+                            this.statusbar.text = `SystemVerilog: Indexing ${processed}/${total}`;
+                            lastReportedPct = pct;
+                        }
+                    }
+                    return undefined;
                 }
             )
-            .then(() => {
+            .then(async () => {
                 console.timeEnd('build_index'); // eslint-disable-line no-console
                 this.building = false;
+                this.symbolsCount = await this.client.count();
                 if (cancelled) {
                     this.statusbar.text = `SystemVerilog: Indexing cancelled at ${this.symbolsCount} indexed objects`;
                 } else {
@@ -120,171 +145,125 @@ export class SystemVerilogIndexer {
     }
 
     /**
-        Processes one file and updates this.symbols with an entry if symbols exist in the file.
+        Processes one file: stat-gates against the on-disk cache (skip if
+        mtime+size match), reads the file text, and delegates parsing +
+        storage to the worker. The extension-host main thread does no CPU
+        work in this path.
 
         @param uri uri to the document
-        @param total_files total number of files to determine parse-precision
+        @param total_files total number of files (kept for API compat; no longer affects precision)
     */
-    public async processFile(uri: Uri, total_files = 0) {
-        // eslint-disable-next-line no-async-promise-executor
-        return new Promise(async (resolve) => {
-            resolve(
-                workspace.openTextDocument(uri).then((doc) => {
-                    if (total_files >= 1000 * this.parallelProcessing || this.forceFastIndexing) {
-                        return this.parser.get_all_recursive(doc, 'fast', 0);
-                    }
-                    if (total_files >= 100 * this.parallelProcessing) {
-                        return this.parser.get_all_recursive(doc, 'declaration', 0);
-                    }
-                    if (doc.lineCount > this.maxLineCountIndexing.valueOf()) {
-                        window.showInformationMessage(
-                            `The character count of ${workspace.asRelativePath(uri)} is larger than ${this.maxLineCountIndexing}. Falling back to fast parse. To fully parse this file, please set 'systemverilog.maxLineCountIndexing > ${doc.lineCount} in the systemverilog extension settings.`
-                        ); // prettier-ignore
-                        return this.parser.get_all_recursive(doc, 'fast', 0);
-                    }
-                    // Otherwise, we parse the file with the precision requested by the user
-                    return this.parser.get_all_recursive(doc, this.documentSymbolPrecision, 1);
-                })
-            );
-        })
-            .then((output: Array<SystemVerilogSymbol>) => {
-                if (output.length > 0) {
-                    if (this.symbols.has(uri.fsPath)) {
-                        this.symbolsCount += output.length - this.symbols.get(uri.fsPath).length;
-                    } else {
-                        this.symbolsCount += output.length;
-                    }
-                    this.symbols.set(uri.fsPath, output);
-                    if (total_files === 0) {
-                        // If total files is 0, it is being used onChange
-                        this.statusbar.text = `SystemVerilog: ${this.symbolsCount} indexed objects`;
-                    }
+    public async processFile(uri: Uri, total_files = 0): Promise<void> {
+        const isSingleFilePath = total_files === 0;
+        try {
+            let mtimeMs = 0;
+            let size = 0;
+            try {
+                const st = await fs.promises.stat(uri.fsPath);
+                mtimeMs = st.mtimeMs;
+                size = st.size;
+                const meta = await this.client.getFileMeta([uri.fsPath]);
+                const cached = meta[uri.fsPath];
+                if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+                    return;
                 }
-            })
-            .catch((error) => {
-                this.outputChannel.appendLine(`SystemVerilog: Indexing: Unable to process file: ${uri.toString()}`);
-                this.outputChannel.appendLine(error);
-                if (this.symbols.has(uri.fsPath)) {
-                    this.symbolsCount -= this.symbols.get(uri.fsPath).length;
-                    this.symbols.delete(uri.fsPath);
-                }
-                return undefined;
+            } catch {
+                // If stat fails the file may have been deleted between glob
+                // and process — fall through and let the parse fail cleanly.
+            }
+
+            // At this point we know we're going to actually re-parse this file.
+            // Surface that in the status bar so the user knows incremental
+            // indexing is happening on save.
+            if (isSingleFilePath) {
+                this.statusbar.text = 'SystemVerilog: Indexing...';
+            }
+
+            // Read text directly from disk (cheaper than workspace.openTextDocument,
+            // which would also pull the file into VSCode's document model).
+            const text = await fs.promises.readFile(uri.fsPath, 'utf8');
+            // Cheap line-count: number of '\n' + 1. Avoids materialising a doc.
+            let lineCount = 1;
+            for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) lineCount++;
+            const precision = this.resolvePrecision(lineCount);
+            const maxDepth = this.maxDepthForPrecision(precision);
+
+            await this.client.parseAndUpsert({
+                path: uri.fsPath,
+                mtimeMs,
+                size,
+                text,
+                precision,
+                maxDepth
             });
+
+            if (isSingleFilePath) {
+                this.symbolsCount = await this.client.count();
+                this.statusbar.text = `SystemVerilog: ${this.symbolsCount} indexed objects`;
+            }
+        } catch (error) {
+            this.outputChannel.appendLine(`SystemVerilog: Indexing: Unable to process file: ${uri.toString()}`);
+            this.outputChannel.appendLine(String(error));
+            try {
+                await this.client.deleteFile(uri.fsPath);
+            } catch {
+                /* swallow */
+            }
+            // Restore the status bar even on error so it doesn't stay at "Indexing...".
+            if (isSingleFilePath) {
+                try {
+                    this.symbolsCount = await this.client.count();
+                    this.statusbar.text = `SystemVerilog: ${this.symbolsCount} indexed objects`;
+                } catch {
+                    /* swallow */
+                }
+            }
+        }
     }
 
     /**
-        Removes the given `document`'s symbols from `this.symbols`,
-        Gets the current symbols which exist on the document to add to `this.symbols`.
-        Updates the status bar with the current symbols count in the workspace.
-
-        @param document the document that's been changed
-        @return status message when indexing is successful or failed with an error.
+        Re-indexes the given document if it is a SystemVerilog/Verilog file
+        and incremental indexing is enabled.
     */
     public async onChange(document: TextDocument): Promise<any> {
-        return new Promise(() => {
-            if (!isSystemVerilogDocument(document) && !isVerilogDocument(document) && !isVerilogAMSDocument(document)) {
-                return;
-            }
-            if (!workspace.getConfiguration().get('systemverilog.enableIncrementalIndexing')) {
-                return;
-            }
-            if (
-                !minimatch(
-                    document.uri.toString(),
-                    workspace.getConfiguration().get('systemverilog.excludeIndexing').toString()
-                )
-            ) {
-                this.outputChannel.appendLine('Auto Indexing: ' + document.uri.toString());
-                return this.processFile(document.uri);
-            }
-        });
+        if (!isSystemVerilogDocument(document) && !isVerilogDocument(document) && !isVerilogAMSDocument(document)) {
+            return undefined;
+        }
+        if (!workspace.getConfiguration().get('systemverilog.enableIncrementalIndexing')) {
+            return undefined;
+        }
+        if (
+            !minimatch(
+                document.uri.toString(),
+                workspace.getConfiguration().get('systemverilog.excludeIndexing').toString()
+            )
+        ) {
+            this.outputChannel.appendLine('Auto Indexing: ' + document.uri.toString());
+            return this.processFile(document.uri);
+        }
+        return undefined;
     }
 
-    /**
-        Adds the given `document`'s symbols to `this.symbols`.
-        Updates the status bar with the current symbols count in the workspace.
-
-        @param uri the document's Uri
-        @return status message when indexing is successful or failed with an error.
-    */
     public async onCreate(uri: Uri): Promise<any> {
-        return new Promise(() => workspace.openTextDocument(uri).then((document) => this.onChange(document)));
+        const document = await workspace.openTextDocument(uri);
+        return this.onChange(document);
     }
 
-    /**
-        Removes the given `document`'s symbols from `this.symbols`.
-        Updates the status bar with the current symbols count in the workspace.
-
-        @param uri the document's Uri
-        @return status message when indexing is successful or failed with an error.
-    */
     public async onDelete(uri: Uri): Promise<any> {
-        return new Promise(() => workspace.openTextDocument(uri).then((document) => this.onChange(document)));
+        await this.client.deleteFile(uri.fsPath);
+        this.symbolsCount = await this.client.count();
+        this.statusbar.text = `SystemVerilog: ${this.symbolsCount} indexed objects`;
     }
 
     /**
-        Adds the given `document`'s symbols to `symbolsMap`.
-
-        @param fsPath the file path to the document
-        @param symbolsMap the symbols map
-        @return number of added files
-    */
-    addDocumentSymbols(document: TextDocument, symbolsMap: Map<string, Array<SystemVerilogSymbol>>): Thenable<number> {
-        // eslint-disable-next-line no-async-promise-executor
-        return new Promise(async (resolve) => {
-            if (!document || !symbolsMap) {
-                resolve(new Array<SystemVerilogSymbol>());
-                return;
-            }
-
-            if (!isSystemVerilogDocument(document) && !isVerilogDocument(document) && !isVerilogAMSDocument(document)) {
-                resolve(new Array<SystemVerilogSymbol>());
-                return;
-            }
-
-            resolve(
-                workspace
-                    .openTextDocument(document.uri)
-                    .then((doc) => this.parser.get_all_recursive(doc, 'declaration', 1))
-            );
-        }).then((output: Array<SystemVerilogSymbol>) => {
-            if (output.length > 0) {
-                symbolsMap.set(document.uri.fsPath, output);
-            }
-            return output.length;
-        });
-    }
-
-    /**
-        Removes the given `document`'s symbols from `symbolsMap`.
-
-        @param fsPath the file path to the document
-        @param symbolsMap the symbols map
-        @return number of deleted files multiplied by -1
-    */
-    removeDocumentSymbols(fsPath: string, symbolsMap: Map<string, Array<SystemVerilogSymbol>>): number {
-        if (!fsPath || !symbolsMap) {
-            return 0;
-        }
-
-        let deletedCount = 0;
-
-        if (symbolsMap.has(fsPath)) {
-            deletedCount = symbolsMap.get(fsPath).length;
-            symbolsMap.delete(fsPath);
-        }
-
-        return deletedCount * -1;
-    }
-
-    /**
-        Updates `mostRecentSymbols` with the most recently used symbols
-        When `mostRecentSymbols` is undefined, add the top `this.NUM_FILES` symbol from `this.symbols`
-        When `mostRecentSymbols` is defined, add the symbols in `recentSymbols` one by one to the top of the array
+        Updates `mostRecentSymbols` with the most recently used symbols.
+        When `recentSymbols` is undefined, populates from the SQLite index
+        using parsed_at ordering. When provided, splices the supplied entries
+        to the top of the in-memory cap-N list.
 
         @param recentSymbols the recent symbols
     */
-    updateMostRecentSymbols(recentSymbols: Array<SystemVerilogSymbol>): void {
+    public async updateMostRecentSymbols(recentSymbols: Array<SystemVerilogSymbol>): Promise<void> {
         if (this.mostRecentSymbols) {
             if (!recentSymbols) {
                 return;
@@ -293,7 +272,6 @@ export class SystemVerilogIndexer {
             while (recentSymbols.length > 0) {
                 const currentSymbol = recentSymbols.pop();
 
-                // If symbol already exists, remove it
                 for (let i = 0; i < this.mostRecentSymbols.length; i++) {
                     const symbol = this.mostRecentSymbols[i];
                     if (symbol === currentSymbol) {
@@ -302,29 +280,16 @@ export class SystemVerilogIndexer {
                     }
                 }
 
-                // If the array has reached maximum capacity, remove the last element
                 if (this.mostRecentSymbols.length >= this.NUM_FILES) {
                     this.mostRecentSymbols.pop();
                 }
 
-                // Add the symbol to the top of the array
                 this.mostRecentSymbols.unshift(currentSymbol);
             }
-        } else {
-            let maxSymbols = new Array<SystemVerilogSymbol>();
-
-            // Collect the top symbols in `this.symbols`
-            for (const list of this.symbols.values()) {
-                if (maxSymbols.length + list.length >= this.NUM_FILES) {
-                    const limit = this.NUM_FILES - maxSymbols.length;
-                    maxSymbols = maxSymbols.concat(list.slice(-1 * limit));
-                    break;
-                } else {
-                    maxSymbols = maxSymbols.concat(list);
-                }
-            }
-
-            this.mostRecentSymbols = maxSymbols;
+            return;
         }
+
+        const rows = await this.client.getMostRecent(this.NUM_FILES);
+        this.mostRecentSymbols = rows.map(wireToSymbol);
     }
 }

--- a/src/parser-core.ts
+++ b/src/parser-core.ts
@@ -1,0 +1,515 @@
+// Pure-JS SystemVerilog parser. Operates on a `ParseSource` (string + lazy
+// line-offset table), returns plain wire-shape symbols. Has no vscode imports
+// so it can run inside the indexer worker.
+
+import { SymbolWire } from './wire-types';
+import { getSymbolKindInt } from './symbol-kinds';
+
+export interface ParseSource {
+    text: string;
+    fsPath: string;
+    positionAt(offset: number): { line: number; character: number };
+    lineCount: number;
+    lineAt(line: number): { text: string };
+}
+
+type Pos = { line: number; character: number };
+
+function posBeforeOrEqual(a: Pos, b: Pos): boolean {
+    if (a.line < b.line) return true;
+    if (a.line > b.line) return false;
+    return a.character <= b.character;
+}
+
+function posGreaterThan(a: Pos, b: Pos): boolean {
+    if (a.line > b.line) return true;
+    if (a.line < b.line) return false;
+    return a.character > b.character;
+}
+
+/** Wraps a plain string + fsPath so it satisfies `ParseSource`. */
+export class StringSource implements ParseSource {
+    public text: string;
+    public fsPath: string;
+    private _lineStarts: number[] | null = null;
+
+    constructor(text: string, fsPath: string) {
+        this.text = text;
+        this.fsPath = fsPath;
+    }
+
+    private get lineStarts(): number[] {
+        if (this._lineStarts) return this._lineStarts;
+        const ls = [0];
+        const t = this.text;
+        for (let i = 0; i < t.length; i++) {
+            if (t.charCodeAt(i) === 10 /* \n */) ls.push(i + 1);
+        }
+        this._lineStarts = ls;
+        return ls;
+    }
+
+    get lineCount(): number {
+        return this.lineStarts.length;
+    }
+
+    positionAt(offset: number): Pos {
+        const ls = this.lineStarts;
+        if (offset <= 0) return { line: 0, character: 0 };
+        if (offset >= this.text.length) {
+            const lastLine = ls.length - 1;
+            return { line: lastLine, character: this.text.length - ls[lastLine] };
+        }
+        let lo = 0;
+        let hi = ls.length - 1;
+        while (lo < hi) {
+            const mid = (lo + hi + 1) >>> 1;
+            if (ls[mid] <= offset) lo = mid;
+            else hi = mid - 1;
+        }
+        return { line: lo, character: offset - ls[lo] };
+    }
+
+    lineAt(line: number): { text: string } {
+        const ls = this.lineStarts;
+        if (line < 0 || line >= ls.length) return { text: '' };
+        const start = ls[line];
+        const end = line + 1 < ls.length ? ls[line + 1] - 1 : this.text.length;
+        let endTrim = end;
+        if (endTrim > start && this.text.charCodeAt(endTrim - 1) === 13 /* \r */) endTrim--;
+        return { text: this.text.slice(start, endTrim) };
+    }
+}
+
+export class SystemVerilogParser {
+    private illegalMatches =
+        /(?!\breturn\b|\bbegin\b|\bend\b|\belse\b|\bjoin\b|\bfork\b|\bfor\b|\bif\b|\bvirtual\b|\bstatic\b|\bautomatic\b|\bgenerate\b|\bassign\b|\binitial\b|\bassert\b|\bdisable\b)/;
+    private comment = /(?:\/\/.*$)?/;
+
+    private r_decl_block = new RegExp(
+        [
+            '(?<=^\\s*',
+            /(?<type>module|program|interface|package|primitive|config|property)\s+/,
+            /(?:automatic\s+)?/,
+            ')',
+            /(?<name>\w+)/,
+            /(?<params>\s*#\s*\([\w\W]*?\))?/,
+            /(?<ports>\s*\([\W\w]*?\))?/,
+            /\s*;/,
+            /(?<body>[\W\w]*?)/,
+            /(?<end>end\1)/ // eslint-disable-line no-useless-backreference
+        ]
+            .map((x) => (typeof x === 'string' ? x : x.source))
+            .join(''),
+        'mg'
+    );
+
+    private r_decl_class = new RegExp(
+        [
+            '(?<=^\\s*(virtual\\s+)?',
+            /(?<type>class)\s+/,
+            ')',
+            /(?<name>\w+)/,
+            /(\s+(extends|implements)\s+[\w\W]+?|\s*#\s*\([\w\W]+?\))*?/,
+            /\s*;/,
+            /(?<body>[\w\W]*?)/,
+            /(?<end>endclass)/
+        ]
+            .map((x) => (typeof x === 'string' ? x : x.source))
+            .join(''),
+        'mg'
+    );
+
+    private r_decl_method = new RegExp(
+        [
+            '(?<=^\\s*(virtual|local|extern|pure\\s+virtual)?\\s*',
+            /(?<type>(function|task))\s+/,
+            /(?<return>[\w:[\]\s*]+\s*)?/,
+            ')',
+            /\b(?<name>[\w.]+)\b\s*/,
+            /(?<ports>\([\W\w]*?\))?/,
+            /\s*;/,
+            /(?<body>[\w\W]*?)/,
+            /(?<end>end(function|task))/
+        ]
+            .map((x) => (typeof x === 'string' ? x : x.source))
+            .join(''),
+        'mg'
+    );
+
+    private r_typedef = new RegExp(
+        [
+            /(?<=^\s*)/,
+            /(?<type>typedef\b)\s*((?!;|\{)[\W\w])+/,
+            /(\{(?<body>\{(\{|[\W\w]+?)\}|[\W\w]+?)\}|[\w\W]+?\})?\s*/,
+            /(?<name>\b\w+\b)/,
+            /(?:\s*\[[^;]*?\])*?/,
+            /\s*(?<end>;)/
+        ]
+            .map((x) => x.source)
+            .join(''),
+        'mg'
+    );
+
+    private r_instantiation = new RegExp(
+        [
+            '(?<=^\\s*',
+            /(?:(?<modifier>virtual|static|automatic|rand|randc|pure virtual)\s+)?/,
+            this.illegalMatches,
+            /\b(?<type>[:\w]+(?:\s*\[[^\]]*?\])*?)\s*/,
+            this.comment,
+            /(?<params>#\s*\([\w\W]*?\))?\s*/,
+            /(\b\w+\s*,\s*)*?/,
+            ')',
+            this.illegalMatches,
+            /\b(?<name>\w+)\s*/,
+            /(?:(\[[^\]]*?\]\s*)*?|(\([\w\W]*?\))?)\s*/,
+            /\s*(?<end>;|,|=)/
+        ]
+            .map((x) => (typeof x === 'string' ? x : x.source))
+            .join(''),
+        'mg'
+    );
+
+    private r_assert = new RegExp(
+        [/(?<=^\s*(?<name>\w+)\s*:\s*)/, /(?<type>assert\b)/]
+            .map((x) => (typeof x === 'string' ? x : x.source))
+            .join(''),
+        'mg'
+    );
+
+    private r_potential_reference = new RegExp(
+        [this.illegalMatches, /\b(?<name>\w+)\b/].map((x) => (typeof x === 'string' ? x : x.source)).join(''),
+        'mg'
+    );
+
+    private r_define = new RegExp(
+        [
+            /(?<=^\s*)/,
+            /`(?<type>define)\s+/,
+            /(?<name>\w+)\b/,
+            /((?<ports>\([^\n]*\))|\s*?)/,
+            /(?<body>([^\n]*\\\n)*([^\n]*))/,
+            /(?<!\\)(?=\n)/
+        ]
+            .map((x) => x.source)
+            .join(''),
+        'mg'
+    );
+
+    private r_label = new RegExp(
+        [
+            /\b(?<type>begin)\b/,
+            /\s*:\s*/,
+            /(?<name>\w+)\s*(?:\/\/.*)?$/,
+            /(?<body>(?:\bbegin\b(?:\bbegin\b(?:\bbegin\b(?:\bbegin\b(?:\bbegin\b[\w\W]+?\bend\b|[\w\W])+?\bend\b|[\w\W])+?\bend\b|[\w\W])+?\bend\b|[\w\W])+?\bend\b|[\w\W])+?)/,
+            /\bend\b(\s*:\s*\1)?/ // eslint-disable-line no-useless-backreference
+        ]
+            .map((x) => x.source)
+            .join(''),
+        'mg'
+    );
+
+    private r_ports = new RegExp(
+        [
+            /(?:\b(?:input|output|inout|interface)\b)\s*/,
+            /(?<type>(?:`?\w+)?\s*(\[.*?\])*?)?\s*/,
+            /(\b\w+\s*,\s*)*?/,
+            /(?<name>\b\w+\b)/,
+            /(?=\s*((\[.*?\]\s*)*?|\/\/[^\n]*\s*)(?:,|\)))/
+        ]
+            .map((x) => (typeof x === 'string' ? x : x.source))
+            .join(''),
+        'mg'
+    );
+
+    private r_params: RegExp = new RegExp(
+        [
+            /(?<type>parameter)/,
+            /(?:(\s+(?<data_type>\w+))*)/,
+            /(?:\s*\[.*?\]\s*)*?/,
+            /\s+(?<name>\w+)\s*/
+        ]
+            .map((x) => (typeof x === 'string' ? x : x.source))
+            .join(''),
+        'mg'
+    );
+
+    private r_block_fast = new RegExp(
+        [
+            /(?<=^\s*(?:virtual\s+)?)/,
+            /(?<type>module|class|interface|package|program)\s+/,
+            /(?:automatic\s+)?/,
+            /(?<name>\w+)/,
+            /[\w\W.]*?/,
+            /(end\1)/ // eslint-disable-line no-useless-backreference
+        ]
+            .map((x) => x.source)
+            .join(''),
+        'mg'
+    );
+
+    public readonly full_parse = [
+        this.r_decl_block,
+        this.r_decl_class,
+        this.r_decl_method,
+        this.r_typedef,
+        this.r_define,
+        this.r_label,
+        this.r_instantiation,
+        this.r_assert,
+        this.r_potential_reference
+    ];
+
+    public readonly full_parse_no_references = [
+        this.r_decl_block,
+        this.r_decl_class,
+        this.r_decl_method,
+        this.r_typedef,
+        this.r_define,
+        this.r_label,
+        this.r_instantiation,
+        this.r_assert
+    ];
+
+    public readonly declaration_parse = [
+        this.r_decl_block,
+        this.r_decl_class,
+        this.r_decl_method,
+        this.r_typedef,
+        this.r_define
+    ];
+
+    public readonly fast_parse = [this.r_block_fast];
+
+    public parse(source: ParseSource, precision: string, maxDepth: number): SymbolWire[] {
+        // Pre-compute comment ranges once per file.
+        let blockCommentStart: Pos[] = [];
+        let blockCommentEnd: Pos[] = [];
+        if (precision.includes('full')) {
+            blockCommentStart = this.findAll(source, source.text, /(?<!\/)\/\*/g, 0);
+            blockCommentEnd = this.findAll(source, source.text, /\*\//g, 0);
+        }
+        // Cheap whole-file pre-scans to decide which regexes are worth running.
+        // Each of these has expensive worst-case backtracking; skipping a regex
+        // when its anchoring keyword isn't in the file is always safe (the
+        // regex couldn't match anyway) and dramatically cheaper.
+        const t = source.text;
+        const skip = new Set<RegExp>();
+        if (!/\bbegin\b\s*:\s*\w+/.test(t)) skip.add(this.r_label);
+        if (!/\btypedef\b/.test(t)) skip.add(this.r_typedef);
+        if (!/`define\b/.test(t)) skip.add(this.r_define);
+        if (!/\b(?:function|task)\b/.test(t)) skip.add(this.r_decl_method);
+        if (!/\bclass\b/.test(t)) skip.add(this.r_decl_class);
+        if (!/\bassert\b/.test(t)) skip.add(this.r_assert);
+        if (!/\b(?:module|program|interface|package|primitive|config|property)\b/.test(t)) {
+            skip.add(this.r_decl_block);
+            skip.add(this.r_block_fast);
+        }
+        return this.parseRecursive(
+            source,
+            precision,
+            maxDepth,
+            source.text,
+            0,
+            '',
+            0,
+            blockCommentStart,
+            blockCommentEnd,
+            skip
+        );
+    }
+
+    private parseRecursive(
+        source: ParseSource,
+        precision: string,
+        maxDepth: number,
+        text: string,
+        offset: number,
+        parent: string,
+        depth: number,
+        blockCommentStart: Pos[],
+        blockCommentEnd: Pos[],
+        skip: Set<RegExp>
+    ): SymbolWire[] {
+        let symbols: SymbolWire[] = [];
+        const subBlocks: Array<{ match: RegExpMatchArray; bodyOffset: number }> = [];
+
+        const regexes = this.translatePrecision(precision);
+
+        for (let i = 0; i < regexes.length; i++) {
+            // Skip regexes whose anchoring keyword doesn't appear in the file.
+            // The pre-scan happens once per parse() call in `parse()`.
+            if (skip.has(regexes[i])) continue;
+
+            // Reset regex state to make this re-entrant.
+            regexes[i].lastIndex = 0;
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+                const match: RegExpMatchArray = regexes[i].exec(text);
+                if (match == null) break;
+                const type = match.groups!.type ? match.groups!.type : 'potential_reference';
+                if (match.index === 0 && parent !== '') continue;
+                if (
+                    type !== 'potential_reference' &&
+                    subBlocks.some(
+                        (b) =>
+                            match.index! >= b.match.index! &&
+                            match.index! < b.match.index! + b.match[0].length
+                    )
+                ) continue;
+
+                const start = source.positionAt(match.index! + offset);
+                const end = source.positionAt(match.index! + match[0].length + offset);
+
+                if (!this.isInsideComment(source, start, blockCommentStart, blockCommentEnd)) {
+                    const name = match.groups!.name;
+                    symbols.push({
+                        name,
+                        type,
+                        kind: getSymbolKindInt(type),
+                        container: parent || null,
+                        file: source.fsPath,
+                        sl: start.line,
+                        sc: start.character,
+                        el: end.line,
+                        ec: end.character
+                    });
+
+                    if (match.groups!.ports && precision.includes('full')) {
+                        symbols.push(
+                            ...this.getPorts(
+                                source,
+                                match.groups!.ports,
+                                offset + match.index! + match[0].indexOf(match.groups!.ports),
+                                name
+                            )
+                        );
+                    }
+                    if (match.groups!.params && precision.includes('full')) {
+                        symbols.push(
+                            ...this.getParams(
+                                source,
+                                match.groups!.params,
+                                offset + match.index! + match[0].indexOf(match.groups!.params),
+                                name
+                            )
+                        );
+                    }
+                    if (match.groups!.body) {
+                        subBlocks.push({
+                            match,
+                            bodyOffset: match.index! + offset + match[0].indexOf(match.groups!.body)
+                        });
+                    }
+                }
+            }
+        }
+
+        if (depth !== maxDepth) {
+            for (const b of subBlocks) {
+                symbols = symbols.concat(
+                    this.parseRecursive(
+                        source,
+                        precision,
+                        maxDepth,
+                        b.match.groups!.body,
+                        b.bodyOffset,
+                        b.match.groups!.name,
+                        depth + 1,
+                        blockCommentStart,
+                        blockCommentEnd,
+                        skip
+                    )
+                );
+            }
+        }
+        return symbols;
+    }
+
+    private translatePrecision(precision: string): RegExp[] {
+        switch (precision) {
+            case 'full':
+                return this.full_parse;
+            case 'full_no_references':
+                return this.full_parse_no_references;
+            case 'declaration':
+                return this.declaration_parse;
+            case 'fast':
+                return this.fast_parse;
+            default:
+                throw new Error(`Illegal precision: ${precision}`);
+        }
+    }
+
+    private getPorts(source: ParseSource, text: string, offset: number, parent: string): SymbolWire[] {
+        const out: SymbolWire[] = [];
+        const re = new RegExp(this.r_ports.source, this.r_ports.flags);
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const m = re.exec(text);
+            if (m == null) break;
+            const start = source.positionAt(m.index! + offset);
+            const end = source.positionAt(m.index! + m[0].length + offset);
+            out.push({
+                name: m.groups!.name,
+                type: m.groups!.type || '',
+                kind: getSymbolKindInt(m.groups!.type || ''),
+                container: parent,
+                file: source.fsPath,
+                sl: start.line,
+                sc: start.character,
+                el: end.line,
+                ec: end.character
+            });
+        }
+        return out;
+    }
+
+    private getParams(source: ParseSource, text: string, offset: number, parent: string): SymbolWire[] {
+        const out: SymbolWire[] = [];
+        const re = new RegExp(this.r_params.source, this.r_params.flags);
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const m = re.exec(text);
+            if (m == null) break;
+            const start = source.positionAt(m.index! + offset);
+            const end = source.positionAt(m.index! + m[0].length + offset);
+            out.push({
+                name: m.groups!.name,
+                type: m.groups!.type,
+                kind: getSymbolKindInt(m.groups!.type),
+                container: parent,
+                file: source.fsPath,
+                sl: start.line,
+                sc: start.character,
+                el: end.line,
+                ec: end.character
+            });
+        }
+        return out;
+    }
+
+    private isInsideComment(source: ParseSource, start: Pos, commentStart: Pos[], commentEnd: Pos[]): boolean {
+        const line = source.lineAt(start.line).text;
+        if (/^\s*\/\/.*/.test(line)) return true;
+        if (commentStart.length === 0) return false;
+        const lastStart = commentStart.find((x) => posBeforeOrEqual(x, start));
+        const lastEnd = commentEnd.find((x) => posBeforeOrEqual(x, start));
+        // posGreaterThan(lastStart, lastEnd) means there is an unclosed `/*` before `start`.
+        if (lastStart && (!lastEnd || posGreaterThan(lastStart, lastEnd))) return true;
+        return false;
+    }
+
+    private findAll(source: ParseSource, text: string, regex: RegExp, offset: number): Pos[] {
+        const out: Pos[] = [];
+        const re = new RegExp(regex.source, regex.flags);
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const m = re.exec(text);
+            if (m == null) break;
+            out.push(source.positionAt(m.index! + offset));
+        }
+        return out;
+    }
+}

--- a/src/parser-core.ts
+++ b/src/parser-core.ts
@@ -76,7 +76,7 @@ export class StringSource implements ParseSource {
         const start = ls[line];
         const end = line + 1 < ls.length ? ls[line + 1] - 1 : this.text.length;
         let endTrim = end;
-        if (endTrim > start && this.text.charCodeAt(endTrim - 1) === 13 /* \r */) endTrim--;
+        if (endTrim > start && this.text.charCodeAt(endTrim - 1) === 13 /* \r */) endTrim -= 1;
         return { text: this.text.slice(start, endTrim) };
     }
 }
@@ -84,6 +84,7 @@ export class StringSource implements ParseSource {
 export class SystemVerilogParser {
     private illegalMatches =
         /(?!\breturn\b|\bbegin\b|\bend\b|\belse\b|\bjoin\b|\bfork\b|\bfor\b|\bif\b|\bvirtual\b|\bstatic\b|\bautomatic\b|\bgenerate\b|\bassign\b|\binitial\b|\bassert\b|\bdisable\b)/;
+
     private comment = /(?:\/\/.*$)?/;
 
     private r_decl_block = new RegExp(
@@ -224,12 +225,7 @@ export class SystemVerilogParser {
     );
 
     private r_params: RegExp = new RegExp(
-        [
-            /(?<type>parameter)/,
-            /(?:(\s+(?<data_type>\w+))*)/,
-            /(?:\s*\[.*?\]\s*)*?/,
-            /\s+(?<name>\w+)\s*/
-        ]
+        [/(?<type>parameter)/, /(?:(\s+(?<data_type>\w+))*)/, /(?:\s*\[.*?\]\s*)*?/, /\s+(?<name>\w+)\s*/]
             .map((x) => (typeof x === 'string' ? x : x.source))
             .join(''),
         'mg'
@@ -353,11 +349,10 @@ export class SystemVerilogParser {
                 if (
                     type !== 'potential_reference' &&
                     subBlocks.some(
-                        (b) =>
-                            match.index! >= b.match.index! &&
-                            match.index! < b.match.index! + b.match[0].length
+                        (b) => match.index! >= b.match.index! && match.index! < b.match.index! + b.match[0].length
                     )
-                ) continue;
+                )
+                    continue;
 
                 const start = source.positionAt(match.index! + offset);
                 const end = source.positionAt(match.index! + match[0].length + offset);

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -3,118 +3,97 @@ import { getSymbolKind } from '../symbol';
 import { regexGetIndexes } from '../utils/common';
 
 export class SystemVerilogDefinitionProvider implements DefinitionProvider {
-    public provideDefinition(
+    public async provideDefinition(
         document: TextDocument,
         position: Position,
         token: CancellationToken
     ): Promise<Definition> {
-        return new Promise<Definition>((resolve, _reject) => {
+        try {
             const range = document.getWordRangeAtPosition(position);
+            if (!range) return [];
+
             const line = document.lineAt(position.line).text;
             const word = document.getText(range);
-            const results: Location[] = [];
 
-            if (!range) {
-                return undefined;
-            }
-            if (isLineInsideComments()) {
-                return undefined;
-            }
+            if (isLineInsideComments(document, range, line)) return [];
 
             const matchPort = line.match(`\\.\\s*${word}\\s*\\(`);
             const matchPackage = line.match(`\\b(\\w+)\\s*::\\s*(${word})`);
 
-            // Return a promise to find object in a portlist
+            // Port connection: ".port(expr)" — definition is the port in the
+            // surrounding module's declaration.
             if (matchPort && matchPort.index === range.start.character - 1) {
                 const container = moduleFromPort(document, range);
-                if (container) {
-                    commands
-                        .executeCommand('vscode.executeWorkspaceSymbolProvider', `¤${container}`)
-                        .then((res: SymbolInformation[]) => {
-                            const locationPromises = res.map((x) => {
-                                return commands
-                                    .executeCommand('vscode.executeDocumentSymbolProvider', x.location.uri, word)
-                                    .then((symbols: Array<SymbolInformation | DocumentSymbol>) => {
-                                        return extractLocations(symbols, word, x.location.uri, container);
-                                    });
-                            });
-
-                            Promise.all(locationPromises).then((locLists: Location[][]) => {
-                                locLists.forEach((locList: Location[]) => results.push(...locList));
-                                resolve(results);
-                            });
-                        });
+                if (!container) return [];
+                const res = (await commands.executeCommand<SymbolInformation[]>(
+                    'vscode.executeWorkspaceSymbolProvider',
+                    `¤${container}`,
+                    token
+                )) || [];
+                const locs: Location[] = [];
+                for (const x of res) {
+                    if (token.isCancellationRequested) break;
+                    const symbols = (await commands.executeCommand<Array<SymbolInformation | DocumentSymbol>>(
+                        'vscode.executeDocumentSymbolProvider',
+                        x.location.uri,
+                        word
+                    )) || [];
+                    locs.push(...extractLocations(symbols, word, x.location.uri, container));
                 }
-            }
-            // Return a promise to find object in a package
-            else if (matchPackage && line.indexOf(word, matchPackage.index) === range.start.character) {
-                commands
-                    .executeCommand('vscode.executeWorkspaceSymbolProvider', `¤${matchPackage[1]}`, token)
-                    .then((ws_symbols: SymbolInformation[]) => {
-                        if (ws_symbols.length && ws_symbols[0].location) {
-                            return ws_symbols[0].location.uri;
-                        }
-                    })
-                    .then((uri) => {
-                        if (uri) {
-                            return commands
-                                .executeCommand('vscode.executeDocumentSymbolProvider', uri, word)
-                                .then((symbols: Array<DocumentSymbol | SymbolInformation>) => {
-                                    resolve(extractLocations(symbols, word, uri, matchPackage[1]));
-                                });
-                        } else {
-                            resolve(undefined);
-                        }
-                    });
-            }
-            // Lookup all symbols in the current document
-            else {
-                commands
-                    .executeCommand('vscode.executeDocumentSymbolProvider', document.uri, word, token)
-                    .then((res: Array<DocumentSymbol | SymbolInformation>) => {
-                        let o = extractLocations(res, word, document.uri);
-                        if (o.length) {
-                            resolve(o);
-                        } else {
-                            // Look up all indexed symbols
-                            commands
-                                .executeCommand('vscode.executeWorkspaceSymbolProvider', `¤${word}`, token)
-                                .then((syms: SymbolInformation[]) => {
-                                    resolve(syms.map((x) => x.location));
-                                });
-                        }
-                    });
+                return locs;
             }
 
-            function isLineInsideComments(): Boolean {
-                /* eslint-disable spaced-comment */
-                //is line commented out with a single line comment (//)?
-                const isSingleComment = /^\s*\/\/.*/.test(line);
-                if (isSingleComment) {
-                    return true;
-                }
-                // only look at text before symbol. If we see a begin comment, an end comment
-                // must be implied and we can ignore looking for one
-                const text = document.getText(new Range(new Position(0, 0), range.start));
-                // Get the locations of begin and end comment blocks
-                const commentStart = regexGetIndexes(document, text, /(?<!\/)\/\*/g, 0);
-                const commentEnd = regexGetIndexes(document, text, /\*\//g, 0);
-
-                // only look at text before symbol. If we see a begin comment, an end comment
-                // must be implied and we can ignore looking for one
-                const lastStartComment = commentStart.find((x) => x.isBeforeOrEqual(range.start));
-                const lastEndComment = commentEnd.find((x) => x.isBeforeOrEqual(range.start));
-
-                // If there is begin comment (/*) that is not yet closed,
-                // we know the symbol must be commented out.
-                if (lastStartComment > lastEndComment) {
-                    // we must be within a block comment
-                    return true;
-                }
-                return false;
+            // Package-qualified name: "Pkg::name" — definition is in Pkg.
+            if (matchPackage && line.indexOf(word, matchPackage.index) === range.start.character) {
+                const wsSyms = (await commands.executeCommand<SymbolInformation[]>(
+                    'vscode.executeWorkspaceSymbolProvider',
+                    `¤${matchPackage[1]}`,
+                    token
+                )) || [];
+                if (wsSyms.length === 0 || !wsSyms[0].location) return [];
+                const uri = wsSyms[0].location.uri;
+                const symbols = (await commands.executeCommand<Array<DocumentSymbol | SymbolInformation>>(
+                    'vscode.executeDocumentSymbolProvider',
+                    uri,
+                    word
+                )) || [];
+                return extractLocations(symbols, word, uri, matchPackage[1]);
             }
-        });
+
+            // Default path: look in the current document first, then workspace.
+            const docSyms = (await commands.executeCommand<Array<DocumentSymbol | SymbolInformation>>(
+                'vscode.executeDocumentSymbolProvider',
+                document.uri,
+                word,
+                token
+            )) || [];
+            const localLocs = extractLocations(docSyms, word, document.uri);
+            if (localLocs.length) return localLocs;
+
+            const wsSyms = (await commands.executeCommand<SymbolInformation[]>(
+                'vscode.executeWorkspaceSymbolProvider',
+                `¤${word}`,
+                token
+            )) || [];
+            return wsSyms.map((x) => x.location);
+        } catch {
+            // Any failure — most often a cancelled executeCommand — surfaces
+            // as an empty Definition rather than a hung promise.
+            return [];
+        }
     }
+}
+
+function isLineInsideComments(document: TextDocument, range: Range, line: string): boolean {
+    /* eslint-disable spaced-comment */
+    if (/^\s*\/\/.*/.test(line)) return true;
+    const text = document.getText(new Range(new Position(0, 0), range.start));
+    const commentStart = regexGetIndexes(document, text, /(?<!\/)\/\*/g, 0);
+    const commentEnd = regexGetIndexes(document, text, /\*\//g, 0);
+    const lastStart = commentStart.find((x) => x.isBeforeOrEqual(range.start));
+    const lastEnd = commentEnd.find((x) => x.isBeforeOrEqual(range.start));
+    if (lastStart && (!lastEnd || lastStart.isAfter(lastEnd))) return true;
+    return false;
 }
 
 function flattenDocumentSymbols(docSyms) {

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -25,19 +25,21 @@ export class SystemVerilogDefinitionProvider implements DefinitionProvider {
             if (matchPort && matchPort.index === range.start.character - 1) {
                 const container = moduleFromPort(document, range);
                 if (!container) return [];
-                const res = (await commands.executeCommand<SymbolInformation[]>(
-                    'vscode.executeWorkspaceSymbolProvider',
-                    `¤${container}`,
-                    token
-                )) || [];
+                const res =
+                    (await commands.executeCommand<SymbolInformation[]>(
+                        'vscode.executeWorkspaceSymbolProvider',
+                        `¤${container}`,
+                        token
+                    )) || [];
                 const locs: Location[] = [];
                 for (const x of res) {
                     if (token.isCancellationRequested) break;
-                    const symbols = (await commands.executeCommand<Array<SymbolInformation | DocumentSymbol>>(
-                        'vscode.executeDocumentSymbolProvider',
-                        x.location.uri,
-                        word
-                    )) || [];
+                    const symbols =
+                        (await commands.executeCommand<Array<SymbolInformation | DocumentSymbol>>(
+                            'vscode.executeDocumentSymbolProvider',
+                            x.location.uri,
+                            word
+                        )) || [];
                     locs.push(...extractLocations(symbols, word, x.location.uri, container));
                 }
                 return locs;
@@ -45,36 +47,40 @@ export class SystemVerilogDefinitionProvider implements DefinitionProvider {
 
             // Package-qualified name: "Pkg::name" — definition is in Pkg.
             if (matchPackage && line.indexOf(word, matchPackage.index) === range.start.character) {
-                const wsSyms = (await commands.executeCommand<SymbolInformation[]>(
-                    'vscode.executeWorkspaceSymbolProvider',
-                    `¤${matchPackage[1]}`,
-                    token
-                )) || [];
+                const wsSyms =
+                    (await commands.executeCommand<SymbolInformation[]>(
+                        'vscode.executeWorkspaceSymbolProvider',
+                        `¤${matchPackage[1]}`,
+                        token
+                    )) || [];
                 if (wsSyms.length === 0 || !wsSyms[0].location) return [];
                 const uri = wsSyms[0].location.uri;
-                const symbols = (await commands.executeCommand<Array<DocumentSymbol | SymbolInformation>>(
-                    'vscode.executeDocumentSymbolProvider',
-                    uri,
-                    word
-                )) || [];
+                const symbols =
+                    (await commands.executeCommand<Array<DocumentSymbol | SymbolInformation>>(
+                        'vscode.executeDocumentSymbolProvider',
+                        uri,
+                        word
+                    )) || [];
                 return extractLocations(symbols, word, uri, matchPackage[1]);
             }
 
             // Default path: look in the current document first, then workspace.
-            const docSyms = (await commands.executeCommand<Array<DocumentSymbol | SymbolInformation>>(
-                'vscode.executeDocumentSymbolProvider',
-                document.uri,
-                word,
-                token
-            )) || [];
+            const docSyms =
+                (await commands.executeCommand<Array<DocumentSymbol | SymbolInformation>>(
+                    'vscode.executeDocumentSymbolProvider',
+                    document.uri,
+                    word,
+                    token
+                )) || [];
             const localLocs = extractLocations(docSyms, word, document.uri);
             if (localLocs.length) return localLocs;
 
-            const wsSyms = (await commands.executeCommand<SymbolInformation[]>(
-                'vscode.executeWorkspaceSymbolProvider',
-                `¤${word}`,
-                token
-            )) || [];
+            const wsSyms =
+                (await commands.executeCommand<SymbolInformation[]>(
+                    'vscode.executeWorkspaceSymbolProvider',
+                    `¤${word}`,
+                    token
+                )) || [];
             return wsSyms.map((x) => x.location);
         } catch {
             // Any failure — most often a cancelled executeCommand — surfaces

--- a/src/providers/DocumentSymbolProvider.ts
+++ b/src/providers/DocumentSymbolProvider.ts
@@ -1,16 +1,13 @@
 import { DocumentSymbolProvider, SymbolInformation, CancellationToken, TextDocument, Uri, SymbolKind, Location, Position, workspace } from 'vscode' // prettier-ignore
 import { SystemVerilogIndexer } from '../indexer';
-import { SystemVerilogParser } from '../parser';
-import { getSymbolKind, SystemVerilogSymbol } from '../symbol';
+import { SystemVerilogSymbol, wireToSymbol } from '../symbol';
 
 export class SystemVerilogDocumentSymbolProvider implements DocumentSymbolProvider {
-    private parser: SystemVerilogParser;
     private indexer: SystemVerilogIndexer;
     private precision: string;
     private depth = -1;
 
-    constructor(parser, indexer) {
-        this.parser = parser;
+    constructor(indexer: SystemVerilogIndexer) {
         this.indexer = indexer;
         const settings = workspace.getConfiguration();
         this.precision = settings.get('systemverilog.documentSymbolsPrecision');
@@ -22,40 +19,46 @@ export class SystemVerilogDocumentSymbolProvider implements DocumentSymbolProvid
     }
 
     /**
-        Matches the regex pattern with the document's text. If a match is found, it creates a `SystemVerilogSymbol` object.
-        If `documentSymbols` is not `undefined`, than the object is added to it,
-        otherwise add the objects to an empty list and return it.
+        Returns the symbols for the given document. Prefers the cached symbols
+        in the shard-backed index; on a cache miss, asks the worker to parse
+        the document so the main thread stays responsive.
 
         @param document The document in which the command was invoked.
-        @param _token A cancellation token.
-        @return A list of `SystemVerilogSymbol` objects or a thenable that resolves to such. The lack of a result can be
-        signaled by returning `undefined`, `null`, or an empty list.
+        @return A list of `SystemVerilogSymbol` objects.
     */
-    public provideDocumentSymbols(
+    public async provideDocumentSymbols(
         document: TextDocument,
         _token?: CancellationToken
-    ): Thenable<Array<SystemVerilogSymbol>> {
-        return new Promise((resolve) => {
-            let symbols = [];
-            const path = document.uri.fsPath;
-            const allSymbols = this.indexer.symbols.get(path);
-            if (allSymbols) {
-                allSymbols.forEach((symbol) => {
-                    if (symbol.kind !== getSymbolKind('potential_reference')) {
-                        symbols.push(symbol);
-                    }
-                });
-            } else {
-                symbols = this.parser.get_all_recursive(document, this.precision, this.depth);
-            }
-            /*
-            Matches the regex and uses the index from the regex to find the position
-            TODO: Look through the symbols to check if it either is defined in the current file or in the workspace.
-                  Use that information to figure out if an instanciated 'unknown' object is of a known type.
-            */
-            resolve(symbols);
-            // resolve(show_SymbolKinds(document.uri));
+    ): Promise<Array<SystemVerilogSymbol>> {
+        const fspath = document.uri.fsPath;
+        const rows = await this.indexer.client.getFileSymbols(fspath, [
+            'potential_reference'
+        ]);
+        if (rows.length > 0) {
+            return rows.map(wireToSymbol);
+        }
+        // No non-reference symbols. If the file is known to the index already,
+        // there's nothing to show — don't re-parse, or we'd overwrite the
+        // `potential_reference` rows that Find References depends on.
+        const meta = await this.indexer.client.getFileMeta([fspath]);
+        if (meta[fspath]) {
+            return [];
+        }
+        // Truly not indexed yet — parse on demand in the worker without
+        // mutating the cache.
+        const text = document.getText();
+        const depth = this.depth >= 0
+            ? this.depth
+            : this.precision === 'full' || this.precision === 'full_no_references' ? 1 : 0;
+        const wireSyms = await this.indexer.client.parseText({
+            path: fspath,
+            text,
+            precision: this.precision,
+            maxDepth: depth
         });
+        return wireSyms
+            .filter((s) => s.type !== 'potential_reference')
+            .map(wireToSymbol);
     }
 }
 

--- a/src/providers/DocumentSymbolProvider.ts
+++ b/src/providers/DocumentSymbolProvider.ts
@@ -31,9 +31,7 @@ export class SystemVerilogDocumentSymbolProvider implements DocumentSymbolProvid
         _token?: CancellationToken
     ): Promise<Array<SystemVerilogSymbol>> {
         const fspath = document.uri.fsPath;
-        const rows = await this.indexer.client.getFileSymbols(fspath, [
-            'potential_reference'
-        ]);
+        const rows = await this.indexer.client.getFileSymbols(fspath, ['potential_reference']);
         if (rows.length > 0) {
             return rows.map(wireToSymbol);
         }
@@ -47,18 +45,15 @@ export class SystemVerilogDocumentSymbolProvider implements DocumentSymbolProvid
         // Truly not indexed yet — parse on demand in the worker without
         // mutating the cache.
         const text = document.getText();
-        const depth = this.depth >= 0
-            ? this.depth
-            : this.precision === 'full' || this.precision === 'full_no_references' ? 1 : 0;
+        const depth =
+            this.depth >= 0 ? this.depth : this.precision === 'full' || this.precision === 'full_no_references' ? 1 : 0;
         const wireSyms = await this.indexer.client.parseText({
             path: fspath,
             text,
             precision: this.precision,
             maxDepth: depth
         });
-        return wireSyms
-            .filter((s) => s.type !== 'potential_reference')
-            .map(wireToSymbol);
+        return wireSyms.filter((s) => s.type !== 'potential_reference').map(wireToSymbol);
     }
 }
 

--- a/src/providers/ReferenceProvider.ts
+++ b/src/providers/ReferenceProvider.ts
@@ -28,21 +28,17 @@ export class SystemVerilogReferenceProvider implements ReferenceProvider {
         const defLocation = await this.getDefinitionLocation(document, position, token);
         if (defLocation === undefined) return [];
 
-        const allSymbols =
-            ((await commands.executeCommand<SymbolInformation[]>(
-                'vscode.executeWorkspaceSymbolProvider',
-                `¬¤${word}`,
-                token
-            )) || []) as SymbolInformation[];
+        const allSymbols = ((await commands.executeCommand<SymbolInformation[]>(
+            'vscode.executeWorkspaceSymbolProvider',
+            `¬¤${word}`,
+            token
+        )) || []) as SymbolInformation[];
 
         // Per-candidate timeout + cancellation guard so one stuck provider
         // call cannot stall the whole search.
         const results: Location[] = [];
         const checks = allSymbols.map((symbol) =>
-            withTimeout(
-                this.isLocationDefinedByDefinition(symbol.location, token, defLocation),
-                CANDIDATE_TIMEOUT_MS
-            )
+            withTimeout(this.isLocationDefinedByDefinition(symbol.location, token, defLocation), CANDIDATE_TIMEOUT_MS)
                 .then((r) => {
                     if (r !== undefined) results.push(r);
                 })
@@ -84,11 +80,7 @@ export class SystemVerilogReferenceProvider implements ReferenceProvider {
         } catch {
             return undefined;
         }
-        const thisDefLocation = await this.getDefinitionLocation(
-            document,
-            location.range.start,
-            token
-        );
+        const thisDefLocation = await this.getDefinitionLocation(document, location.range.start, token);
         if (thisDefLocation === undefined) return undefined;
         if (!this.includeDeclaration && this.isLocationShallowEqual(location, defLocation)) {
             return undefined;

--- a/src/providers/ReferenceProvider.ts
+++ b/src/providers/ReferenceProvider.ts
@@ -1,9 +1,13 @@
 import { ReferenceProvider, TextDocument, Position, workspace, Location, CancellationToken, SymbolInformation, commands } from 'vscode'; // prettier-ignore
 import { SystemVerilogDefinitionProvider } from './DefinitionProvider';
 
+// Cap how long any single per-candidate definition lookup is allowed to take.
+// Without this, a single never-resolving provider promise would hang the
+// entire Find References operation via Promise.all.
+const CANDIDATE_TIMEOUT_MS = 3000;
+
 export class SystemVerilogReferenceProvider implements ReferenceProvider {
     public definitionProvider: SystemVerilogDefinitionProvider;
-    public results: Location[];
     public includeDeclaration: Boolean;
 
     public constructor(definitionProvider) {
@@ -16,101 +20,105 @@ export class SystemVerilogReferenceProvider implements ReferenceProvider {
         options: { includeDeclaration: boolean },
         token: CancellationToken
     ): Promise<Location[]> {
-        // eslint-disable-next-line no-async-promise-executor
-        return new Promise<Location[]>(async (resolve, _reject) => {
-            const range = document.getWordRangeAtPosition(position);
-            const word = document.getText(range);
-            this.results = [];
-            const promises: Promise<Location>[] = [];
-            this.includeDeclaration = options.includeDeclaration;
+        this.includeDeclaration = options.includeDeclaration;
+        const range = document.getWordRangeAtPosition(position);
+        if (!range) return [];
 
-            if (!range) {
-                resolve(this.results);
-            }
+        const word = document.getText(range);
+        const defLocation = await this.getDefinitionLocation(document, position, token);
+        if (defLocation === undefined) return [];
 
-            // Get the original definition of the symbol 'Location' so we can compare against other symbols we find
-            const defLocation = await this.getDefinitionLocation(document, position, token);
-
-            // Get all symbols in the workspace that match `word`
-            const allSymbols: SymbolInformation[] = await commands.executeCommand(
+        const allSymbols =
+            ((await commands.executeCommand<SymbolInformation[]>(
                 'vscode.executeWorkspaceSymbolProvider',
                 `¬¤${word}`,
                 token
-            );
+            )) || []) as SymbolInformation[];
 
-            if (defLocation !== undefined) {
-                // For each file in the workspace
-                for (const symbol of allSymbols) {
-                    // Find any tokens symbols (word) that that reference back to the Location we found above
-                    promises.push(this.isLocationDefinedByDefinition(symbol.location, token, defLocation));
-                }
-                // Run all promises in parallel
-                this.results = await Promise.all(promises);
+        // Per-candidate timeout + cancellation guard so one stuck provider
+        // call cannot stall the whole search.
+        const results: Location[] = [];
+        const checks = allSymbols.map((symbol) =>
+            withTimeout(
+                this.isLocationDefinedByDefinition(symbol.location, token, defLocation),
+                CANDIDATE_TIMEOUT_MS
+            )
+                .then((r) => {
+                    if (r !== undefined) results.push(r);
+                })
+                .catch(() => undefined)
+        );
 
-                // filter out undefined locations (i.e. non references)
-                this.results = this.results.filter((x) => x !== undefined);
-            }
-
-            resolve(this.results);
-        });
+        await Promise.all(checks);
+        return results;
     }
 
-    // Get the Location of the word at a given Postition
-    // This function is used to get the Location of the word under the suer's cursor
-    // when getting references.
     public async getDefinitionLocation(
         document: TextDocument,
         position: Position,
         token: CancellationToken
     ): Promise<Location> {
-        const res = await this.definitionProvider.provideDefinition(document, position, token);
-        let defLocation: Location;
-        if (typeof res === typeof Location) {
-            defLocation = res as Location;
-        } else if (res[0] !== null) {
-            defLocation = res[0] as Location;
-        } else {
-            defLocation = new Location(document.uri, position);
+        let res;
+        try {
+            res = await this.definitionProvider.provideDefinition(document, position, token);
+        } catch {
+            res = undefined;
         }
-        return defLocation;
+        if (Array.isArray(res)) {
+            if (res.length === 0) return new Location(document.uri, position);
+            return res[0] as Location;
+        }
+        if (res) return res as Location;
+        return new Location(document.uri, position);
     }
 
-    // Find the definition of the symbol at `location`. If the declared Location matches
-    // when we do a reverse search for the symbol's location, we know we have found
-    // a reference of the symbol.
     public async isLocationDefinedByDefinition(
         location: Location,
         token: CancellationToken,
-        defLocation: Location // The definition we are testing against
+        defLocation: Location
     ): Promise<Location> {
-        // Read the document into memory
-        const document = await workspace.openTextDocument(location.uri);
-        // Find all references to the word `symbol`
-
-        // Get the definition (i.e. declaration) of the found symbol Locations
-        const thisDefLocation = await this.getDefinitionLocation(document, location.range.start, token);
-        if (thisDefLocation === undefined) {
-            // we found a symbol in a comment probably
+        if (token.isCancellationRequested) return undefined;
+        let document: TextDocument;
+        try {
+            document = await workspace.openTextDocument(location.uri);
+        } catch {
             return undefined;
         }
-        // don't include the definition in the list when it is not requested
+        const thisDefLocation = await this.getDefinitionLocation(
+            document,
+            location.range.start,
+            token
+        );
+        if (thisDefLocation === undefined) return undefined;
         if (!this.includeDeclaration && this.isLocationShallowEqual(location, defLocation)) {
             return undefined;
         }
         if (this.isLocationShallowEqual(thisDefLocation, defLocation)) {
-            // The declaration of the symbol matches hte original Location the user requested.
             return location;
         }
-
         return undefined;
     }
 
-    // We can't compare Location objects with `==` we have to compare the properties using this function
     private isLocationShallowEqual(location1: Location, location2: Location): Boolean {
         if (location1.uri.path === location2.uri.path) {
-            // If the start location is the same. we know the end location must also match
             return location1.range.start.isEqual(location2.range.start);
         }
         return false;
     }
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error('candidate timeout')), ms);
+        p.then(
+            (v) => {
+                clearTimeout(t);
+                resolve(v);
+            },
+            (err) => {
+                clearTimeout(t);
+                reject(err);
+            }
+        );
+    });
 }

--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -1,13 +1,8 @@
 import { WorkspaceSymbolProvider, CancellationToken } from 'vscode';
 import { SystemVerilogIndexer } from '../indexer';
-import { getSymbolKind, SystemVerilogSymbol } from '../symbol';
+import { getSymbolKind, SystemVerilogSymbol, wireToSymbol } from '../symbol';
 
 export class SystemVerilogWorkspaceSymbolProvider implements WorkspaceSymbolProvider {
-    /*
-     * this.symbols: filePath => Array<SystemVerilogSymbol>
-     * each entry's key represents a file path,
-     * and the entry's value is a list of the symbols that exist in the file
-     */
     public indexer: SystemVerilogIndexer;
 
     public NUM_FILES = 250;
@@ -17,71 +12,51 @@ export class SystemVerilogWorkspaceSymbolProvider implements WorkspaceSymbolProv
     }
 
     /**
-        Queries a symbol from `this.symbols`, performs an exact match if `exactMatch` is set to true,
-        and a partial match if it's not passed or set to false.
+        Queries a symbol by name, performing an exact match if the query is
+        prefixed with `¤`, otherwise a fuzzy case-insensitive match.
 
-        @param query the symbol's name. If it is prepended with a ¤ it signifies an exact match. If it is prepended with a ¬ it signifies to cull potential matches from the results.
+        @param query the symbol's name. Prefix with `¤` for exact match,
+                     prefix with `¬` to include potential references.
         @param token the CancellationToken
         @return an array of matching SystemVerilogSymbol
     */
-    public provideWorkspaceSymbols(query: string, token: CancellationToken): Thenable<Array<SystemVerilogSymbol>> {
-        return new Promise((resolve, _reject) => {
-            if (query === undefined || query.length === 0) {
-                this.indexer.updateMostRecentSymbols(undefined);
-                resolve(this.indexer.mostRecentSymbols);
-            } else {
-                const pattern = new RegExp(`.*${query.replace(" ", "").split("").map((c) => c).join(".*")}.*`, 'i'); // prettier-ignore
-                const results = new Array<SystemVerilogSymbol>();
-                let exactMatch: Boolean = false;
-                let ignorePotentialReferences: Boolean = true;
-                if (query.startsWith('¬')) {
-                    ignorePotentialReferences = false;
-                    query = query.substr(1);
-                }
-                if (query.startsWith('¤')) {
-                    exactMatch = true;
-                    query = query.substr(1);
-                }
-                this.indexer.symbols.forEach((list) => {
-                    if (token.isCancellationRequested) {
-                        resolve(undefined);
-                    }
-                    list.forEach((symbol) => {
-                        if (token.isCancellationRequested) {
-                            resolve(undefined);
-                        }
-                        if (exactMatch === true) {
-                            if (symbol.name === query) {
-                                if (
-                                    !ignorePotentialReferences ||
-                                    symbol.kind !== getSymbolKind('potential_reference')
-                                ) {
-                                    results.push(symbol);
-                                }
-                            }
-                        } else if (symbol.name.match(pattern)) {
-                            if (!ignorePotentialReferences || symbol.kind !== getSymbolKind('potential_reference')) {
-                                results.push(symbol);
-                            }
-                        }
-                    });
-                });
+    public async provideWorkspaceSymbols(
+        query: string,
+        token: CancellationToken
+    ): Promise<Array<SystemVerilogSymbol>> {
+        if (query === undefined || query.length === 0) {
+            await this.indexer.updateMostRecentSymbols(undefined);
+            return this.indexer.mostRecentSymbols;
+        }
 
-                this.indexer.updateMostRecentSymbols(results.slice(0)); // pass a shallow copy of the array
-                resolve(this.uniquifyResults(results));
-            }
-        });
+        let exactMatch = false;
+        let ignorePotentialReferences = true;
+        if (query.startsWith('¬')) {
+            ignorePotentialReferences = false;
+            query = query.substr(1);
+        }
+        if (query.startsWith('¤')) {
+            exactMatch = true;
+            query = query.substr(1);
+        }
+
+        const excludeTypes = ignorePotentialReferences ? ['potential_reference'] : undefined;
+        const rows = exactMatch
+            ? await this.indexer.client.queryByName(query, { excludeTypes })
+            : await this.indexer.client.queryFuzzy(query, { excludeTypes });
+
+        if (token.isCancellationRequested) {
+            return undefined;
+        }
+
+        const results = rows.map(wireToSymbol);
+        await this.indexer.updateMostRecentSymbols(results.slice(0));
+        return this.uniquifyResults(results);
     }
 
-    public getAllModules(): Thenable<Array<SystemVerilogSymbol>> {
-        return new Promise((resolve) => {
-            let modules: Array<SystemVerilogSymbol> = [];
-            this.indexer.symbols.forEach((list) => {
-                const foundModules = list.filter((symbol) => symbol.kind === getSymbolKind('module'));
-                modules = modules.concat(foundModules);
-            });
-            resolve(modules);
-        });
+    public async getAllModules(): Promise<Array<SystemVerilogSymbol>> {
+        const rows = await this.indexer.client.getAllByType('module');
+        return rows.map(wireToSymbol);
     }
 
     // filter out duplicate locations if any.
@@ -112,30 +87,22 @@ export class SystemVerilogWorkspaceSymbolProvider implements WorkspaceSymbolProv
     }
 
     /**
-        Queries a `module` with a given name from `this.symbols`, performs an exact match if `exactMatch` is set to true,
-        and a partial match if it's not passed or set to false.
+        Queries a `module` with a given name, performing an exact match.
         @param query the symbol's name
         @return the module's SystemVerilogSymbol
     */
-    public provideWorkspaceModule(query: string): SystemVerilogSymbol {
+    public async provideWorkspaceModule(query: string): Promise<SystemVerilogSymbol> {
         if (query.length === 0) {
             return undefined;
         }
-        let symbolInfo;
-        this.indexer.symbols.forEach((list) => {
-            list.forEach((symbol) => {
-                if (symbol.name === query && symbol.kind === getSymbolKind('module')) {
-                    symbolInfo = symbol;
-                    return false;
-                }
-            });
-
-            if (symbolInfo) {
-                return false;
-            }
-        });
-
-        this.indexer.updateMostRecentSymbols([symbolInfo]);
-        return symbolInfo;
+        const rows = await this.indexer.client.queryByName(query, { limit: 50 });
+        const moduleKind = getSymbolKind('module');
+        const match = rows.find((r) => r.kind === moduleKind);
+        if (!match) {
+            return undefined;
+        }
+        const symbol = wireToSymbol(match);
+        await this.indexer.updateMostRecentSymbols([symbol]);
+        return symbol;
     }
 }

--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -20,10 +20,7 @@ export class SystemVerilogWorkspaceSymbolProvider implements WorkspaceSymbolProv
         @param token the CancellationToken
         @return an array of matching SystemVerilogSymbol
     */
-    public async provideWorkspaceSymbols(
-        query: string,
-        token: CancellationToken
-    ): Promise<Array<SystemVerilogSymbol>> {
+    public async provideWorkspaceSymbols(query: string, token: CancellationToken): Promise<Array<SystemVerilogSymbol>> {
         if (query === undefined || query.length === 0) {
             await this.indexer.updateMostRecentSymbols(undefined);
             return this.indexer.mostRecentSymbols;

--- a/src/symbol-kinds.ts
+++ b/src/symbol-kinds.ts
@@ -1,0 +1,110 @@
+// Numeric mirror of vscode's SymbolKind enum. Kept in sync manually so the
+// parser-core / worker can return SymbolWire rows without importing vscode.
+// The integer values match `vscode.SymbolKind`.
+
+export const SymbolKind = {
+    File: 0,
+    Module: 1,
+    Namespace: 2,
+    Package: 3,
+    Class: 4,
+    Method: 5,
+    Property: 6,
+    Field: 7,
+    Constructor: 8,
+    Enum: 9,
+    Interface: 10,
+    Function: 11,
+    Variable: 12,
+    Constant: 13,
+    String: 14,
+    Number: 15,
+    Boolean: 16,
+    Array: 17,
+    Object: 18,
+    Key: 19,
+    Null: 20,
+    EnumMember: 21,
+    Struct: 22,
+    Event: 23,
+    Operator: 24,
+    TypeParameter: 25
+} as const;
+
+export function getSymbolKindInt(name: string): number {
+    if (name === undefined || name === '') return SymbolKind.Variable;
+    if (name.indexOf('[') !== -1) return SymbolKind.Array;
+    switch (name) {
+        case 'parameter':
+        case 'localparam':
+        case 'Constant':
+            return SymbolKind.Constant;
+        case 'potential_reference':
+        case 'Key':
+            return SymbolKind.Key;
+        case 'package':
+        case 'program':
+        case 'import':
+        case 'Package':
+            return SymbolKind.Package;
+        case 'begin':
+        case 'string':
+        case 'String':
+            return SymbolKind.String;
+        case 'class':
+        case 'Class':
+            return SymbolKind.Class;
+        case 'task':
+        case 'Method':
+            return SymbolKind.Method;
+        case 'function':
+        case 'Function':
+            return SymbolKind.Function;
+        case 'interface':
+        case 'Interface':
+            return SymbolKind.Interface;
+        case 'input':
+        case 'output':
+        case 'inout':
+            return SymbolKind.Boolean;
+        case 'assert':
+        case 'event':
+        case 'Event':
+            return SymbolKind.Event;
+        case 'struct':
+        case 'Struct':
+            return SymbolKind.Struct;
+        case 'typedef':
+        case 'TypeParameter':
+            return SymbolKind.TypeParameter;
+        case 'genvar':
+        case 'Operator':
+            return SymbolKind.Operator;
+        case 'enum':
+        case 'Enum':
+            return SymbolKind.Enum;
+        case 'modport':
+        case 'Null':
+            return SymbolKind.Null;
+        case 'define':
+        case 'property':
+        case 'Property':
+            return SymbolKind.Property;
+        case 'wire':
+        case 'reg':
+        case 'bit':
+        case 'logic':
+        case 'int':
+        case 'integer':
+        case 'char':
+        case 'time':
+        case 'float':
+        case 'Variable':
+            return SymbolKind.Variable;
+        case 'module':
+            // Modules share the Enum icon so the module-instantiator can find them.
+            return SymbolKind.Enum;
+        default:
+            return SymbolKind.Field;
+    }
+}

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,4 +1,8 @@
-import { SymbolInformation, SymbolKind, Location } from 'vscode';
+import { SymbolInformation, SymbolKind, Location, Range, Uri } from 'vscode';
+import { getSymbolKindInt } from './symbol-kinds';
+import { SymbolWire } from './wire-types';
+
+export { SymbolWire } from './wire-types';
 
 export class SystemVerilogSymbol extends SymbolInformation {
     public type: string;
@@ -17,93 +21,32 @@ export class SystemVerilogSymbol extends SymbolInformation {
     }
 }
 
-// See resources/SymbolKind_icons.png for an overview of the available icons
-// Use show_SymbolKinds to see the latest symbols
+export function symbolToWire(s: SystemVerilogSymbol): Omit<SymbolWire, 'file'> {
+    const r = s.location.range;
+    return {
+        name: s.name,
+        type: s.type,
+        kind: s.kind as number,
+        container: s.containerName || null,
+        sl: r.start.line,
+        sc: r.start.character,
+        el: r.end.line,
+        ec: r.end.character
+    };
+}
+
+export function wireToSymbol(w: SymbolWire): SystemVerilogSymbol {
+    return new SystemVerilogSymbol(
+        w.name,
+        w.type,
+        w.container || '',
+        new Location(Uri.file(w.file), new Range(w.sl, w.sc, w.el, w.ec))
+    );
+}
+
+// Host-side façade that returns vscode's SymbolKind enum value. The integer
+// table lives in symbol-kinds.ts so the worker (which can't import vscode)
+// can reuse the same mapping.
 export function getSymbolKind(name: string): SymbolKind {
-    if (name === undefined || name === '') {
-        // Ports may be declared without type
-        return SymbolKind.Variable;
-    }
-    if (name.indexOf('[') !== -1) {
-        return SymbolKind.Array;
-    }
-    switch (name) {
-        case 'parameter':
-        case 'localparam':
-        case 'Constant':
-            return SymbolKind.Constant;
-        case 'potential_reference':
-        case 'Key':
-            return SymbolKind.Key;
-        case 'package':
-        case 'program':
-        case 'import':
-        case 'Package':
-            return SymbolKind.Package;
-        case 'begin': // Labels
-        case 'string':
-        case 'String':
-            return SymbolKind.String;
-        case 'class':
-        case 'Class':
-            return SymbolKind.Class;
-        case 'task':
-        case 'Method':
-            return SymbolKind.Method;
-        case 'function':
-        case 'Function':
-            return SymbolKind.Function;
-        case 'interface':
-        case 'Interface':
-            return SymbolKind.Interface;
-        case 'input':
-        case 'output':
-        case 'inout':
-            return SymbolKind.Boolean;
-        case 'assert':
-        case 'event':
-        case 'Event':
-            return SymbolKind.Event;
-        case 'struct':
-        case 'Struct':
-            return SymbolKind.Struct;
-        case 'typedef':
-        case 'TypeParameter':
-            return SymbolKind.TypeParameter;
-        case 'genvar':
-        case 'Operator':
-            return SymbolKind.Operator;
-        case 'enum':
-        case 'Enum':
-            return SymbolKind.Enum;
-        case 'modport':
-        case 'Null':
-            return SymbolKind.Null;
-        case 'define':
-        case 'property':
-        case 'Property':
-            return SymbolKind.Property;
-        case 'wire':
-        case 'reg':
-        case 'bit':
-        case 'logic':
-        case 'int':
-        case 'integer':
-        case 'char':
-        case 'time':
-        case 'float':
-        case 'Variable':
-            return SymbolKind.Variable;
-        case 'module': // It is important that modules don't share a case with any other kind for the module instantiator to work
-            return SymbolKind.Enum;
-        default:
-            return SymbolKind.Field;
-    }
-    /* Unused/Free SymbolKind icons
-        return SymbolKind.Number;
-        return SymbolKind.Enum;
-        return SymbolKind.EnumMember;
-        return SymbolKind.Operator;
-        return SymbolKind.Array;
-    */
+    return getSymbolKindInt(name) as SymbolKind;
 }

--- a/src/test/indexer_map.test.ts
+++ b/src/test/indexer_map.test.ts
@@ -1,18 +1,14 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { window, workspace, Uri, StatusBarAlignment, Location, Range } from 'vscode';
-import { SystemVerilogDocumentSymbolProvider } from '../providers/DocumentSymbolProvider';
-import { SystemVerilogWorkspaceSymbolProvider } from '../providers/WorkspaceSymbolProvider';
 import { SystemVerilogIndexer } from '../indexer';
-import { SystemVerilogParser } from '../parser';
-import { SystemVerilogSymbol } from '../symbol';
+import { SystemVerilogSymbol, symbolToWire } from '../symbol';
+import { IndexerClient } from '../utils/indexer-client';
 
-let docProvider: SystemVerilogDocumentSymbolProvider;
-let symProvider: SystemVerilogWorkspaceSymbolProvider;
 let indexer: SystemVerilogIndexer;
-let parser: SystemVerilogParser;
-
-let symbols: Map<string, Array<SystemVerilogSymbol>>;
+let client: IndexerClient;
 
 const testFolderLocation = '../../src/test';
 
@@ -21,12 +17,33 @@ const documentSymbols = ['adder', 'bar', 'akker', 'accer', 'anner', 'atter', 'ap
 
 const nonSVUri = Uri.file(path.join(__dirname, testFolderLocation, 'test-files', 'foo.txt'));
 
+async function countSymbols(): Promise<number> {
+    return client.count();
+}
+
+async function symbolExists(name: string): Promise<boolean> {
+    const rows = await client.queryByName(name);
+    return rows.length > 0;
+}
+
 suite('indexer_map Tests', () => {
-    test('test #1: addDocumentSymbols, removeDocumentSymbols', async () => {
+    test('test #1: processFile adds symbols, onDelete removes them', async () => {
         await setUp();
 
-        const sVDocument = await workspace.openTextDocument(uri);
+        await indexer.processFile(uri);
+        const rowsAfterAdd = await client.getFileSymbols(uri.fsPath);
+        assert.ok(rowsAfterAdd.length >= documentSymbols.length, `expected at least ${documentSymbols.length} symbols`); // prettier-ignore
+
+        for (const name of documentSymbols) {
+            // eslint-disable-next-line no-await-in-loop
+            assert.strictEqual(await symbolExists(name), true, `symbol '${name}' should exist after processFile`);
+        }
+
+        // Non-SV document is a no-op via onChange's language gate.
         const nonSVDocument = await workspace.openTextDocument(nonSVUri);
+        await indexer.onChange(nonSVDocument);
+        const meta = await client.getFileMeta([nonSVUri.fsPath]);
+        assert.strictEqual(meta[nonSVUri.fsPath], undefined);
 
         assert.strictEqual(symbols.size, 4);
         let count = await indexer.addDocumentSymbols(sVDocument, symbols);
@@ -69,13 +86,23 @@ suite('indexer_map Tests', () => {
         assert.strictEqual(count, 0);
         assert.strictEqual(symbols.size, 5);
         assert.strictEqual(getSymbolsCount(), 25);
+        // Removing the indexed file clears its symbols.
+        await indexer.onDelete(uri);
+        const rowsAfterDel = await client.getFileSymbols(uri.fsPath);
+        assert.strictEqual(rowsAfterDel.length, 0);
+        for (const name of documentSymbols) {
+            // eslint-disable-next-line no-await-in-loop
+            assert.strictEqual(await symbolExists(name), false, `symbol '${name}' should be gone after onDelete`);
+        }
     });
 
-    test('test #2: removeDocumentSymbols', async () => {
+    test('test #2: deleteFile removes only the targeted file', async () => {
         await setUp();
 
-        const sVDocument = await workspace.openTextDocument(uri);
-        const nonSVDocument = await workspace.openTextDocument(nonSVUri);
+        await indexer.processFile(uri);
+        const fixtureCount = await countSymbols();
+        const fileRows = (await client.getFileSymbols(uri.fsPath)).length;
+        assert.ok(fileRows > 0, 'expected processFile to insert rows');
 
         assert.strictEqual(symbols.size, 4);
         let count = await indexer.addDocumentSymbols(sVDocument, symbols);
@@ -122,20 +149,23 @@ suite('indexer_map Tests', () => {
         assert.strictEqual(count, 0);
         assert.strictEqual(symbols.size, 4);
         assert.strictEqual(getSymbolsCount(), 13);
+        await client.deleteFile(uri.fsPath);
+        assert.strictEqual((await client.getFileSymbols(uri.fsPath)).length, 0);
+        assert.strictEqual(await countSymbols(), fixtureCount - fileRows);
     });
 
-    test('test #3: updateMostRecentModules', async () => {
+    test('test #3: updateMostRecentSymbols populates from index and splices', async () => {
         await setUp();
 
         indexer.NUM_FILES = 5;
-        indexer.symbols = symbols;
-        indexer.updateMostRecentSymbols(undefined);
+        await indexer.updateMostRecentSymbols(undefined);
         assert.strictEqual(indexer.mostRecentSymbols.length, 5);
 
         const recentSymbols = new Array<SystemVerilogSymbol>();
-        const symbolInfo1 = new SystemVerilogSymbol('symbolInfo1', 'module', 'parent_module', undefined);
-        const symbolInfo2 = new SystemVerilogSymbol('symbolInfo2', 'logic', 'parent_logic', undefined);
-        const symbolInfo3 = new SystemVerilogSymbol('symbolInfo3', 'function', 'parent_function', undefined);
+        const dummyLoc = new Location(uri, new Range(0, 0, 0, 0));
+        const symbolInfo1 = new SystemVerilogSymbol('symbolInfo1', 'module', 'parent_module', dummyLoc);
+        const symbolInfo2 = new SystemVerilogSymbol('symbolInfo2', 'logic', 'parent_logic', dummyLoc);
+        const symbolInfo3 = new SystemVerilogSymbol('symbolInfo3', 'function', 'parent_function', dummyLoc);
         const symbolInfo4 = indexer.mostRecentSymbols[0];
         const symbolInfo5 = indexer.mostRecentSymbols[1];
 
@@ -143,7 +173,7 @@ suite('indexer_map Tests', () => {
         recentSymbols.push(symbolInfo2);
         recentSymbols.push(symbolInfo3);
 
-        indexer.updateMostRecentSymbols(recentSymbols);
+        await indexer.updateMostRecentSymbols(recentSymbols);
         assert.strictEqual(indexer.mostRecentSymbols.length, 5);
         assert.strictEqual(indexer.mostRecentSymbols[0], symbolInfo1);
         assert.strictEqual(indexer.mostRecentSymbols[1], symbolInfo2);
@@ -154,21 +184,21 @@ suite('indexer_map Tests', () => {
 });
 
 /**
-  Sets up the `symbols` map for testing.
+  Sets up the indexer with an in-memory SQLite index pre-populated with four
+  fixture files (mirroring the legacy Map-based fixture).
 */
 async function setUp() {
-    const document = await workspace.openTextDocument(uri);
-
-    const settings = workspace.getConfiguration(); // eslint-disable-line @typescript-eslint/no-unused-vars
     const statusBar = window.createStatusBarItem(StatusBarAlignment.Left, 0);
 
-    parser = new SystemVerilogParser();
-    indexer = new SystemVerilogIndexer(statusBar, parser, window.createOutputChannel('SystemVerilog'));
-    docProvider = new SystemVerilogDocumentSymbolProvider(parser, indexer); // eslint-disable-line @typescript-eslint/no-unused-vars
-    symProvider = new SystemVerilogWorkspaceSymbolProvider(indexer); // eslint-disable-line @typescript-eslint/no-unused-vars
+    const storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-index-test-'));
+    client = new IndexerClient({ storageDir, inProcess: true });
+    await client.whenReady();
+    await client.clearAll();
 
-    symbols = new Map<string, Array<SystemVerilogSymbol>>();
+    indexer = new SystemVerilogIndexer(statusBar, window.createOutputChannel('SystemVerilog'), client); // prettier-ignore
+    indexer.initialize();
 
+    const document = await workspace.openTextDocument(uri);
     const location = new Location(
         uri,
         new Range(document.positionAt(0), document.positionAt(document.getText().length))
@@ -176,108 +206,37 @@ async function setUp() {
 
     // File_1
     const file1 = path.join(__dirname, testFolderLocation, 'test-files', 'file_1.v');
-
-    const list1 = new Array<SystemVerilogSymbol>();
-    // Add SystemVerilogSymbol objects to list1
-    const list1SymbolInfo1 = new SystemVerilogSymbol('list_1_SymbolInfo_1', 'module', undefined, location);
-    const list1SymbolInfo2 = new SystemVerilogSymbol('list_1_SymbolInfo_2', 'logic', undefined, location);
-    const list1SymbolInfo3 = new SystemVerilogSymbol('list_1_SymbolInfo_3', 'function', undefined, location);
-    const list1SymbolInfo4 = new SystemVerilogSymbol('list_1_SymbolInfo_4', 'interface', undefined, location);
-
-    list1.push(list1SymbolInfo1);
-    list1.push(list1SymbolInfo2);
-    list1.push(list1SymbolInfo3);
-    list1.push(list1SymbolInfo4);
+    const list1 = [
+        new SystemVerilogSymbol('list_1_SymbolInfo_1', 'module', undefined, location),
+        new SystemVerilogSymbol('list_1_SymbolInfo_2', 'logic', undefined, location),
+        new SystemVerilogSymbol('list_1_SymbolInfo_3', 'function', undefined, location),
+        new SystemVerilogSymbol('list_1_SymbolInfo_4', 'interface', undefined, location)
+    ];
 
     // File_2
     const file2 = path.join(__dirname, testFolderLocation, 'test-files', 'file_2.v');
-
-    const list2 = new Array<SystemVerilogSymbol>();
-    // Add SystemVerilogSymbol objects to list1
-    const list2SymbolInfo1 = new SystemVerilogSymbol('list_2_SymbolInfo_1', 'logic', undefined, location);
-    const list2SymbolInfo2 = new SystemVerilogSymbol('list_2_SymbolInfo_2', 'logic', undefined, location);
-    const list2SymbolInfo3 = new SystemVerilogSymbol('list_2_SymbolInfo_3', 'import', undefined, location);
-
-    list2.push(list2SymbolInfo1);
-    list2.push(list2SymbolInfo2);
-    list2.push(list2SymbolInfo3);
+    const list2 = [
+        new SystemVerilogSymbol('list_2_SymbolInfo_1', 'logic', undefined, location),
+        new SystemVerilogSymbol('list_2_SymbolInfo_2', 'logic', undefined, location),
+        new SystemVerilogSymbol('list_2_SymbolInfo_3', 'import', undefined, location)
+    ];
 
     // File_3
     const file3 = path.join(__dirname, testFolderLocation, 'test-files', 'file_3.v');
+    const list3 = [
+        new SystemVerilogSymbol('list_3_SymbolInfo_1', 'logic', undefined, location),
+        new SystemVerilogSymbol('list_3_SymbolInfo_2', 'logic', undefined, location),
+        new SystemVerilogSymbol('list_3_SymbolInfo_3', 'module', undefined, location),
+        new SystemVerilogSymbol('list_3_SymbolInfo_4', 'module', undefined, location),
+        new SystemVerilogSymbol('list_3_SymbolInfo_5', 'module', undefined, location),
+        new SystemVerilogSymbol('list_3_SymbolInfo_6', 'import', undefined, location)
+    ];
 
-    const list3 = new Array<SystemVerilogSymbol>();
-    // Add SystemVerilogSymbol objects to list1
-    const list3SymbolInfo1 = new SystemVerilogSymbol('list_3_SymbolInfo_1', 'logic', undefined, location);
-    const list3SymbolInfo2 = new SystemVerilogSymbol('list_3_SymbolInfo_2', 'logic', undefined, location);
-    const list3SymbolInfo3 = new SystemVerilogSymbol('list_3_SymbolInfo_3', 'module', undefined, location);
-    const list3SymbolInfo4 = new SystemVerilogSymbol('list_3_SymbolInfo_4', 'module', undefined, location);
-    const list3SymbolInfo5 = new SystemVerilogSymbol('list_3_SymbolInfo_5', 'module', undefined, location);
-    const list3SymbolInfo6 = new SystemVerilogSymbol('list_3_SymbolInfo_6', 'import', undefined, location);
-
-    list3.push(list3SymbolInfo1);
-    list3.push(list3SymbolInfo2);
-    list3.push(list3SymbolInfo3);
-    list3.push(list3SymbolInfo4);
-    list3.push(list3SymbolInfo5);
-    list3.push(list3SymbolInfo6);
-
-    // File_4
+    // File_4 (empty)
     const file4 = path.join(__dirname, testFolderLocation, 'test-files', 'file_4.v');
 
-    const list4 = new Array<SystemVerilogSymbol>();
-
-    // Map the lists to the files
-    symbols.set(file1, list1);
-    symbols.set(file2, list2);
-    symbols.set(file3, list3);
-    symbols.set(file4, list4);
-}
-
-/**
-  Counts `SystemVerilogSymbol` objects in the `symbols` map.
-
-  @return the symbols count
-*/
-function getSymbolsCount(): number {
-    if (!symbols) {
-        return 0;
-    }
-
-    let count = 0;
-
-    symbols.forEach((list) => {
-        count += list.length;
-    });
-
-    return count;
-}
-
-/**
-  Checks if a given `symbolName` exists in the `symbols` map.
-
-  @param symbolName the symbol's name
-  @return true if the symbol exists
-*/
-function symbolExists(symbolName: string): boolean {
-    if (!symbols) {
-        return false;
-    }
-
-    let exists = false;
-
-    symbols.forEach((list) => {
-        list.forEach((symbol: SystemVerilogSymbol) => {
-            if (symbolName === symbol.name) {
-                exists = true;
-            }
-
-            return false;
-        });
-
-        if (exists) {
-            return false;
-        }
-    });
-
-    return exists;
+    await client.upsertFileNow({ path: file1, mtimeMs: 1, size: 1, symbols: list1.map(symbolToWire) });
+    await client.upsertFileNow({ path: file2, mtimeMs: 1, size: 1, symbols: list2.map(symbolToWire) });
+    await client.upsertFileNow({ path: file3, mtimeMs: 1, size: 1, symbols: list3.map(symbolToWire) });
+    await client.upsertFileNow({ path: file4, mtimeMs: 1, size: 1, symbols: [] });
 }

--- a/src/test/indexer_map.test.ts
+++ b/src/test/indexer_map.test.ts
@@ -45,47 +45,6 @@ suite('indexer_map Tests', () => {
         const meta = await client.getFileMeta([nonSVUri.fsPath]);
         assert.strictEqual(meta[nonSVUri.fsPath], undefined);
 
-        assert.strictEqual(symbols.size, 4);
-        let count = await indexer.addDocumentSymbols(sVDocument, symbols);
-
-        assert.strictEqual(count, 12);
-        assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(symbols.get(uri.fsPath).length, 12);
-        assert.strictEqual(getSymbolsCount(), 25);
-
-        documentSymbols.forEach((symbolName) => {
-            if (!symbolExists(symbolName)) {
-                assert.fail();
-            }
-        });
-
-        // Non-SV document
-        count = await indexer.addDocumentSymbols(nonSVDocument, symbols);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(symbols.get(nonSVUri.fsPath), undefined);
-        assert.strictEqual(getSymbolsCount(), 25);
-
-        // undefined/null document
-        count = await indexer.addDocumentSymbols(undefined, symbols);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 25);
-
-        count = await indexer.addDocumentSymbols(sVDocument, undefined);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 25);
-
-        count = await indexer.addDocumentSymbols(undefined, undefined);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 25);
-
-        count = await indexer.addDocumentSymbols(null, symbols);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 25);
         // Removing the indexed file clears its symbols.
         await indexer.onDelete(uri);
         const rowsAfterDel = await client.getFileSymbols(uri.fsPath);
@@ -104,51 +63,8 @@ suite('indexer_map Tests', () => {
         const fileRows = (await client.getFileSymbols(uri.fsPath)).length;
         assert.ok(fileRows > 0, 'expected processFile to insert rows');
 
-        assert.strictEqual(symbols.size, 4);
-        let count = await indexer.addDocumentSymbols(sVDocument, symbols);
-
-        assert.strictEqual(count, 12);
-        assert.strictEqual(symbols.size, 5);
-        assert.strictEqual(getSymbolsCount(), 25);
-
-        count = indexer.removeDocumentSymbols(sVDocument.uri.fsPath, symbols);
-
-        documentSymbols.forEach((symbolName) => {
-            if (symbolExists(symbolName)) {
-                assert.fail();
-            }
-        });
-
-        assert.strictEqual(count, -12);
-        assert.strictEqual(symbols.size, 4);
-        assert.strictEqual(getSymbolsCount(), 13);
-
-        // Non-SV document
-        count = indexer.removeDocumentSymbols(nonSVDocument.uri.fsPath, symbols);
-        assert.strictEqual(count, -0);
-        assert.strictEqual(symbols.size, 4);
-        assert.strictEqual(getSymbolsCount(), 13);
-
-        // undefined/null document
-        count = indexer.removeDocumentSymbols(undefined, symbols);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 4);
-        assert.strictEqual(getSymbolsCount(), 13);
-
-        count = indexer.removeDocumentSymbols(sVDocument.uri.fsPath, undefined);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 4);
-        assert.strictEqual(getSymbolsCount(), 13);
-
-        count = indexer.removeDocumentSymbols(undefined, undefined);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 4);
-        assert.strictEqual(getSymbolsCount(), 13);
-
-        count = indexer.removeDocumentSymbols(null, symbols);
-        assert.strictEqual(count, 0);
-        assert.strictEqual(symbols.size, 4);
-        assert.strictEqual(getSymbolsCount(), 13);
+        // Deleting only the targeted file drops exactly that file's rows,
+        // leaving the other fixtures intact.
         await client.deleteFile(uri.fsPath);
         assert.strictEqual((await client.getFileSymbols(uri.fsPath)).length, 0);
         assert.strictEqual(await countSymbols(), fixtureCount - fileRows);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -16,12 +16,17 @@ async function main() {
 
         const workspacePath = path.resolve(__dirname, '../../verilog-examples');
 
+        // Pin VSCode version so the native better-sqlite3 binary in CI is
+        // built against a known Electron ABI. 1.96.x ships Electron 32
+        // (NODE_MODULE_VERSION 128); see TEST_VSCODE_VERSION below in CI.
+        const vscodeVersion = process.env.TEST_VSCODE_VERSION || '1.96.4';
+
         // Download VS Code, unzip it and run the integration test
         await runTests({
             extensionDevelopmentPath,
             extensionTestsPath,
             launchArgs: [workspacePath, '--disable-workspace-trust', '--disable-extensions'],
-            version: 'stable',
+            version: vscodeVersion,
             timeout: 30000 // 30 seconds (default was 10)
         });
     } catch (err) {

--- a/src/utils/indexer-client.ts
+++ b/src/utils/indexer-client.ts
@@ -54,16 +54,13 @@ export class IndexerClient {
         }
 
         this.worker = new Worker(this.workerPath);
-        this.worker.on(
-            'message',
-            (msg: { id: number; ok: boolean; result?: unknown; error?: string }) => {
-                const call = this.pending.get(msg.id);
-                if (!call) return;
-                this.pending.delete(msg.id);
-                if (msg.ok) call.resolve(msg.result);
-                else call.reject(new Error(msg.error));
-            }
-        );
+        this.worker.on('message', (msg: { id: number; ok: boolean; result?: unknown; error?: string }) => {
+            const call = this.pending.get(msg.id);
+            if (!call) return;
+            this.pending.delete(msg.id);
+            if (msg.ok) call.resolve(msg.result);
+            else call.reject(new Error(msg.error));
+        });
         this.worker.on('error', (err) => this.handleCrash(err));
         this.worker.on('exit', (code) => {
             if (code !== 0 && !this.disposed) {
@@ -88,7 +85,8 @@ export class IndexerClient {
             return Promise.resolve(res.result as T);
         }
         if (!this.worker) return Promise.reject(new Error('indexer worker is not running'));
-        const id = this.nextId++;
+        const id = this.nextId;
+        this.nextId += 1;
         return new Promise<T>((resolve, reject) => {
             this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
             this.worker!.postMessage({ id, method, params });
@@ -179,17 +177,11 @@ export class IndexerClient {
         return this.send('getFileSymbols', { path: filePath, excludeTypes });
     }
 
-    public queryByName(
-        name: string,
-        opts?: { excludeTypes?: string[]; limit?: number }
-    ): Promise<SymbolWire[]> {
+    public queryByName(name: string, opts?: { excludeTypes?: string[]; limit?: number }): Promise<SymbolWire[]> {
         return this.send('queryByName', { name, ...opts });
     }
 
-    public queryFuzzy(
-        pattern: string,
-        opts?: { excludeTypes?: string[]; limit?: number }
-    ): Promise<SymbolWire[]> {
+    public queryFuzzy(pattern: string, opts?: { excludeTypes?: string[]; limit?: number }): Promise<SymbolWire[]> {
         return this.send('queryFuzzy', { pattern, ...opts });
     }
 

--- a/src/utils/indexer-client.ts
+++ b/src/utils/indexer-client.ts
@@ -1,0 +1,226 @@
+import { Worker } from 'worker_threads';
+import * as path from 'path';
+import { ParseAndUpsertParams, ParseTextParams, SymbolWire, UpsertParams } from '../wire-types';
+
+type RpcCall = { resolve: (v: any) => void; reject: (e: any) => void };
+
+export interface IndexerClientOptions {
+    storageDir: string;
+    workerPath?: string; // path to compiled worker .js (when not inProcess)
+    inProcess?: boolean; // run handlers in the same thread (tests)
+    debounceMs?: number; // per-file upsert debounce window
+    onCrash?: (err: Error) => void;
+}
+
+type PendingUpsert = { timer: NodeJS.Timeout; params: UpsertParams };
+
+export class IndexerClient {
+    private worker: Worker | null = null;
+    private inProcess: boolean;
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    private inProcessDispatch: ((req: any) => any) | null = null;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    private nextId = 1;
+    private pending = new Map<number, RpcCall>();
+    private debounceMs: number;
+    private debouncers = new Map<string, PendingUpsert>();
+    private storageDir: string;
+    private workerPath: string;
+    private onCrash: (err: Error) => void;
+    private ready: Promise<void>;
+    private disposed = false;
+
+    constructor(opts: IndexerClientOptions) {
+        this.storageDir = opts.storageDir;
+        this.workerPath = opts.workerPath || path.join(__dirname, 'indexer-worker.js');
+        this.inProcess = !!opts.inProcess;
+        this.debounceMs = opts.debounceMs ?? 300;
+        this.onCrash = opts.onCrash || (() => undefined);
+        this.ready = this.start();
+    }
+
+    private start(): Promise<void> {
+        if (this.inProcess) {
+            // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+            const mod = require('../indexer-worker');
+            this.inProcessDispatch = mod.dispatch;
+            const res = this.inProcessDispatch!({
+                id: 0,
+                method: 'init',
+                params: { storageDir: this.storageDir }
+            });
+            if (!res.ok) return Promise.reject(new Error(res.error));
+            return Promise.resolve();
+        }
+
+        this.worker = new Worker(this.workerPath);
+        this.worker.on(
+            'message',
+            (msg: { id: number; ok: boolean; result?: unknown; error?: string }) => {
+                const call = this.pending.get(msg.id);
+                if (!call) return;
+                this.pending.delete(msg.id);
+                if (msg.ok) call.resolve(msg.result);
+                else call.reject(new Error(msg.error));
+            }
+        );
+        this.worker.on('error', (err) => this.handleCrash(err));
+        this.worker.on('exit', (code) => {
+            if (code !== 0 && !this.disposed) {
+                this.handleCrash(new Error(`indexer worker exited with code ${code}`));
+            }
+        });
+        return this.send('init', { storageDir: this.storageDir });
+    }
+
+    private handleCrash(err: Error): void {
+        // Reject all pending calls so callers don't hang forever.
+        for (const [, call] of this.pending) call.reject(err);
+        this.pending.clear();
+        this.worker = null;
+        this.onCrash(err);
+    }
+
+    private send<T = unknown>(method: string, params?: unknown): Promise<T> {
+        if (this.inProcess) {
+            const res = this.inProcessDispatch!({ id: 0, method, params });
+            if (!res.ok) return Promise.reject(new Error(res.error));
+            return Promise.resolve(res.result as T);
+        }
+        if (!this.worker) return Promise.reject(new Error('indexer worker is not running'));
+        const id = this.nextId++;
+        return new Promise<T>((resolve, reject) => {
+            this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+            this.worker!.postMessage({ id, method, params });
+        });
+    }
+
+    /** Block until the worker has finished `init`. */
+    public whenReady(): Promise<void> {
+        return this.ready;
+    }
+
+    /** Schedule a per-file upsert. Coalesces rapid edits to the same path. */
+    public scheduleUpsert(params: UpsertParams): void {
+        const existing = this.debouncers.get(params.path);
+        if (existing) {
+            clearTimeout(existing.timer);
+        }
+        const timer = setTimeout(() => {
+            this.debouncers.delete(params.path);
+            // Fire and forget; surface errors via onCrash channel.
+            this.send('upsertFile', params).catch((err) => this.onCrash(err as Error));
+        }, this.debounceMs);
+        this.debouncers.set(params.path, { timer, params });
+    }
+
+    /** Flush any pending debounced upsert for a single path immediately. */
+    public async flush(filePath?: string): Promise<void> {
+        if (filePath) {
+            const pending = this.debouncers.get(filePath);
+            if (!pending) return;
+            clearTimeout(pending.timer);
+            this.debouncers.delete(filePath);
+            await this.send('upsertFile', pending.params);
+            return;
+        }
+        const all = [...this.debouncers.values()];
+        this.debouncers.clear();
+        await Promise.all(
+            all.map((p) => {
+                clearTimeout(p.timer);
+                return this.send('upsertFile', p.params);
+            })
+        );
+    }
+
+    public async upsertFileNow(params: UpsertParams): Promise<void> {
+        const existing = this.debouncers.get(params.path);
+        if (existing) {
+            clearTimeout(existing.timer);
+            this.debouncers.delete(params.path);
+        }
+        await this.send('upsertFile', params);
+    }
+
+    /**
+     * Parse a file's text in the worker and store the result. Returns the
+     * number of symbols found. Use this instead of upsertFile when the
+     * caller has the raw text but does not want to parse on the main thread.
+     */
+    public parseAndUpsert(params: ParseAndUpsertParams): Promise<number> {
+        const existing = this.debouncers.get(params.path);
+        if (existing) {
+            clearTimeout(existing.timer);
+            this.debouncers.delete(params.path);
+        }
+        return this.send<number>('parseAndUpsert', params);
+    }
+
+    /** Parse a file's text and return symbols WITHOUT mutating the index. */
+    public parseText(params: ParseTextParams): Promise<SymbolWire[]> {
+        return this.send<SymbolWire[]>('parseText', params);
+    }
+
+    public async deleteFile(filePath: string): Promise<void> {
+        const existing = this.debouncers.get(filePath);
+        if (existing) {
+            clearTimeout(existing.timer);
+            this.debouncers.delete(filePath);
+        }
+        await this.send('deleteFile', { path: filePath });
+    }
+
+    public getFileMeta(paths: string[]): Promise<Record<string, { mtimeMs: number; size: number }>> {
+        return this.send('getFileMeta', { paths });
+    }
+
+    public getFileSymbols(filePath: string, excludeTypes?: string[]): Promise<SymbolWire[]> {
+        return this.send('getFileSymbols', { path: filePath, excludeTypes });
+    }
+
+    public queryByName(
+        name: string,
+        opts?: { excludeTypes?: string[]; limit?: number }
+    ): Promise<SymbolWire[]> {
+        return this.send('queryByName', { name, ...opts });
+    }
+
+    public queryFuzzy(
+        pattern: string,
+        opts?: { excludeTypes?: string[]; limit?: number }
+    ): Promise<SymbolWire[]> {
+        return this.send('queryFuzzy', { pattern, ...opts });
+    }
+
+    public getAllByType(type: string, limit?: number): Promise<SymbolWire[]> {
+        return this.send('getAllByType', { type, limit });
+    }
+
+    public getMostRecent(limit: number): Promise<SymbolWire[]> {
+        return this.send('getMostRecent', { limit });
+    }
+
+    public clearAll(): Promise<void> {
+        return this.send('clearAll');
+    }
+
+    public count(): Promise<number> {
+        return this.send('count');
+    }
+
+    /** Force a synchronous manifest write (best-effort on shutdown). */
+    public flushManifest(): Promise<void> {
+        return this.send('flush');
+    }
+
+    public async dispose(): Promise<void> {
+        this.disposed = true;
+        await this.flush().catch(() => undefined);
+        await this.flushManifest().catch(() => undefined);
+        if (this.worker) {
+            await this.worker.terminate();
+            this.worker = null;
+        }
+    }
+}

--- a/src/wire-types.ts
+++ b/src/wire-types.ts
@@ -1,0 +1,38 @@
+// Plain data types passed between the extension host and the indexer worker.
+// No vscode imports — this module must remain loadable in a worker_threads
+// context that has no access to the vscode runtime.
+
+export type SymbolWire = {
+    name: string;
+    type: string;
+    kind: number;
+    container: string | null;
+    file: string;
+    sl: number;
+    sc: number;
+    el: number;
+    ec: number;
+};
+
+export type UpsertParams = {
+    path: string;
+    mtimeMs: number;
+    size: number;
+    symbols: Array<Omit<SymbolWire, 'file'>>;
+};
+
+export type ParseAndUpsertParams = {
+    path: string;
+    mtimeMs: number;
+    size: number;
+    text: string;
+    precision: string;
+    maxDepth: number;
+};
+
+export type ParseTextParams = {
+    path: string;
+    text: string;
+    precision: string;
+    maxDepth: number;
+};


### PR DESCRIPTION
### Move symbol index to a worker thread with per-file shard storage.

The reference provider's symbol index used to live in a single in-memory Map (indexer.symbols: Map<filePath, SystemVerilogSymbol[]>) that was serialised to context.workspaceState every ~10s after any edit. On workspaces with thousands of large SystemVerilog files this produced millions of SystemVerilogSymbol instances, made the periodic blob write multi-MB, and ran the parser synchronously on the extension-host main thread — causing VSCode to flag the extension "Unresponsive" during initial indexing and lock up for many seconds when a file was re-indexed on save.

This commit replaces the in-memory map + blob persistence with a worker-thread architecture and per-file JSON shards on disk: `storageUri/sv-index/manifest.json`
- `{ version, files: { <fspath>: meta } }`
- `shards/<aa>/<sha1>.json` one shard per indexed source file

The parser runs entirely inside the worker; the extension host does no CPU work for indexing. The host talks to the worker over a small typed RPC layer (IndexerClient) with id-keyed request/reply, per-file upsert debouncing, and crash detection that rejects pending calls cleanly.

### Key behavioural changes

- `processFile` no longer parses: it stats the file (mtime+size gate),
- reads the text with `fs.promises.readFile`, then ships path/text/