### PR TITLE
Add Workspace Trust support for untrusted workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ More details can be found on the [Releases](https://github.com/eirikpre/VSCode-S
 - 💡 Back-end Language Server for Systemverilog
 - 💡 Complete syntax highlighting
 
+### [0.14.1]
+
+* Added Workspace Trust support so syntax highlighting and indexing work in untrusted workspaces ([#262](https://github.com/eirikpre/VSCode-SystemVerilog/issues/262)) by @joecrop
+
 ### [0.14.0]
 
 * Improved reference provider worker by @joecrop

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "systemverilog",
-    "version": "0.13.11",
+    "version": "0.14.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "systemverilog",
-            "version": "0.13.11",
+            "version": "0.14.1",
             "license": "MIT",
             "dependencies": {
                 "antlr4ts": "^0.5.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "systemverilog",
     "displayName": "SystemVerilog - Language Support",
     "description": "Language support for Verilog and SystemVerilog.",
-    "version": "0.13.11",
+    "version": "0.14.1",
     "publisher": "eirikpre",
     "author": {
         "name": "Eirik Prestegårdshus",
@@ -42,6 +42,18 @@
         "workspaceContains:**/*.{sv,v,svh,vh}"
     ],
     "main": "./dist/client/extension",
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": "limited",
+            "description": "Syntax highlighting, snippets and symbol indexing are available in untrusted workspaces. Settings that launch external programs (the compilers and the formatter) only take effect once the workspace is trusted.",
+            "restrictedConfigurations": [
+                "systemverilog.launchConfigurationVerilator",
+                "systemverilog.launchConfigurationVCS",
+                "systemverilog.launchConfigurationVerible",
+                "systemverilog.formatCommand"
+            ]
+        }
+    },
     "contributes": {
         "languages": [
             {


### PR DESCRIPTION
Declare capabilities.untrustedWorkspaces so the extension is no longer fully disabled in untrusted workspaces. Syntax highlighting, snippets and symbol indexing remain available, while the settings that launch external programs (the Verilator/VCS/Verible compilers and the formatter) are listed as restrictedConfigurations and fall back to trusted user/default values until the workspace is trusted.

Fixes #262