### PR TITLE
Fix syntax highlighting for '$' in identifiers and verbose ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ More details can be found on the [Releases](https://github.com/eirikpre/VSCode-S
 - 💡 Back-end Language Server for Systemverilog
 - 💡 Complete syntax highlighting
 
+### [0.14.2]
+
+* Fixed syntax highlighting of net/identifier names containing `$`, such as `n$411` ([#257](https://github.com/eirikpre/VSCode-SystemVerilog/issues/257)) by @joecrop
+* Fixed syntax highlighting of verbose port declarations such as `input wire logic clock` ([#254](https://github.com/eirikpre/VSCode-SystemVerilog/issues/254)) by @joecrop
+
 ### [0.14.1]
 
 * Added Workspace Trust support so syntax highlighting and indexing work in untrusted workspaces ([#262](https://github.com/eirikpre/VSCode-SystemVerilog/issues/262)) by @joecrop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,10 @@ More details can be found on the [Releases](https://github.com/eirikpre/VSCode-S
 - 💡 Back-end Language Server for Systemverilog
 - 💡 Complete syntax highlighting
 
-### [0.14.2]
+### [0.14.1]
 
 * Fixed syntax highlighting of net/identifier names containing `$`, such as `n$411` ([#257](https://github.com/eirikpre/VSCode-SystemVerilog/issues/257)) by @joecrop
 * Fixed syntax highlighting of verbose port declarations such as `input wire logic clock` ([#254](https://github.com/eirikpre/VSCode-SystemVerilog/issues/254)) by @joecrop
-
-### [0.14.1]
-
 * Added Workspace Trust support so syntax highlighting and indexing work in untrusted workspaces ([#262](https://github.com/eirikpre/VSCode-SystemVerilog/issues/262)) by @joecrop
 
 ### [0.14.0]

--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -547,7 +547,7 @@ repository:
   port-net-parameter:
     patterns:
       - match: >-
-          ,?[ \t\r\n]*(?:\b(output|input|inout|ref)\b[ \t\r\n]*)?(?:\b(localparam|parameter|var|supply[01]|tri|triand|trior|trireg|tri[01]|uwire|wire|wand|wor)\b[ \t\r\n]*)?(?:\b([a-zA-Z_][a-zA-Z0-9_$]*)(::))?(?:([a-zA-Z_][a-zA-Z0-9_$]*)\b[ \t\r\n]*)?(?:(#\([ \t\r\n]*[.a-zA-Z_][a-zA-Z0-9_\.\"\'\(\), \t\r\n]*\)[ \t\r\n]*)\b[ \t\r\n]*)?(?:\b(signed|unsigned)\b[ \t\r\n]*)?(?:(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])[ \t\r\n]*)?(?<!(?<!#)[:&|=+\-*/%?><^!~\(][ \t\r\n]*)\b([a-zA-Z_][a-zA-Z0-9_$]*)\b[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?[ \t\r\n]*(?=,|;|=|\)|/|$)
+          ,?[ \t\r\n]*(?:\b(output|input|inout|ref)\b[ \t\r\n]*)?(?:\b(localparam|parameter|var|supply[01]|tri|triand|trior|trireg|tri[01]|uwire|wire|wand|wor)\b[ \t\r\n]*)?(?:\b([a-zA-Z_][a-zA-Z0-9_$]*)(::))?(?:([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \t\r\n]*)?(?:(#\([ \t\r\n]*[.a-zA-Z_][a-zA-Z0-9_\.\"\'\(\), \t\r\n]*\)[ \t\r\n]*)\b[ \t\r\n]*)?(?:\b(signed|unsigned)\b[ \t\r\n]*)?(?:(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])[ \t\r\n]*)?(?<!(?<!#)[:&|=+\-*/%?><^!~\(][ \t\r\n]*)(?<![a-zA-Z0-9_$])([a-zA-Z_][a-zA-Z0-9_$]*)(?![a-zA-Z0-9_$])[ \t\r\n]*(\[[a-zA-Z0-9_:$\.\-\+\*/%`' \t\r\n\[\]\(\)]*\])?[ \t\r\n]*(?=,|;|=|\)|/|$)
         captures:
           '1':
             name: support.type.direction.systemverilog
@@ -703,7 +703,7 @@ repository:
     name: meta.parameters.systemverilog
   identifiers:
     patterns:
-      - match: \b[a-zA-Z_][a-zA-Z0-9_$]*\b
+      - match: \b[a-zA-Z_][a-zA-Z0-9_$]*(?![a-zA-Z0-9_$])
         name: variable.other.identifier.systemverilog
       - match: (?<=^|[ \t\r\n])\\[!-~]+(?=$|[ \t\r\n])
         name: string.regexp.identifier.systemverilog

--- a/verilog-examples/dollar_and_verbose_ports.sv
+++ b/verilog-examples/dollar_and_verbose_ports.sv
@@ -1,0 +1,35 @@
+// Examples for issues #257 (net names containing '$') and #254 (verbose
+// "input wire logic" port syntax). Open this file to visually verify that the
+// names highlight as single identifiers and the verbose ports are recognised.
+
+`default_nettype none
+
+module dollar_and_verbose_ports (
+    // Issue #254: explicit nettype + data type ports (needed under
+    // `default_nettype none). direction + net type + data type + name.
+    input  wire logic        clock,
+    input  wire logic        Rst_b,
+    input  wire logic [7:0]  InData,
+    input  wire logic signed [7:0] SData,
+    output wire logic        OutData
+);
+
+    // Issue #257: '$' is a legal identifier character (since Verilog-1995).
+    // Tool-generated net names frequently contain it.
+    wire        n$411;          // '$' followed by digits
+    logic       n$abc;          // '$' followed by letters
+    logic       foo$;           // trailing '$'
+    logic       n$1, n$2, n$3;  // multiple declarations on one line
+
+    assign n$411 = InData[0];
+    assign n$abc = InData[1];
+    assign foo$  = n$411 & n$abc;
+
+    always_ff @(posedge clock) begin
+        if (Rst_b == 1'b0) OutData <= 1'b0;
+        else               OutData <= foo$;
+    end
+
+endmodule
+
+`default_nettype wire


### PR DESCRIPTION
Issue #257: net/identifier names containing '$' (e.g. n$411) were split when the '$' was followed by a letter (n$abc parsed as type "n$" + net "abc") or appeared at the end of a name (foo$). Because '$' is a non-word character, the \b word boundaries inside the identifier patterns fell in the middle of such names. Replace the relevant \b anchors in port-net-parameter and the identifiers rule with explicit lookarounds that treat '$' as part of the identifier, so the whole name is matched.

Issue #254: add regression coverage for verbose "input wire logic clock" ports (direction + net type + data type), which now highlight correctly.

Adds verilog-examples/dollar_and_verbose_ports.sv covering both cases.

Fixes #257
Fixes #254