### PR TITLE
Fix go-to-definition for module instantiations (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ More details can be found on the [Releases](https://github.com/eirikpre/VSCode-S
 * Fixed syntax highlighting of net/identifier names containing `$`, such as `n$411` ([#257](https://github.com/eirikpre/VSCode-SystemVerilog/issues/257)) by @joecrop
 * Fixed syntax highlighting of verbose port declarations such as `input wire logic clock` ([#254](https://github.com/eirikpre/VSCode-SystemVerilog/issues/254)) by @joecrop
 * Added Workspace Trust support so syntax highlighting and indexing work in untrusted workspaces ([#262](https://github.com/eirikpre/VSCode-SystemVerilog/issues/262)) by @joecrop
+* Fixed go-to-definition on a module instantiation: the module type now resolves to the module definition (even when the instance shares its name), and the instance name itself is no longer treated as a navigation target ([#242](https://github.com/eirikpre/VSCode-SystemVerilog/issues/242)) by @joecrop
 
 ### [0.14.0]
 

--- a/src/providers/DefinitionProvider.ts
+++ b/src/providers/DefinitionProvider.ts
@@ -64,6 +64,40 @@ export class SystemVerilogDefinitionProvider implements DefinitionProvider {
                 return extractLocations(symbols, word, uri, matchPackage[1]);
             }
 
+            // Module instantiation: "ModuleType [#(...)] inst_name (...)". When the
+            // instance is given the same name as its module (issue #242), the local
+            // document-symbol lookup below would resolve the type to the instance
+            // itself. Detect a click on the type position and jump to the module
+            // definition instead. The type is the first token on the line and is
+            // followed by an optional parameter list, the instance name, then '(' or '#'.
+            const beforeWord = line.slice(0, range.start.character);
+            const afterWord = line.slice(range.end.character);
+            const isInstantiationType =
+                /^\s*$/.test(beforeWord) && /^\s*(?:#\s*\([\s\S]*?\)\s*)?[a-zA-Z_]\w*\s*[#(]/.test(afterWord);
+            if (isInstantiationType) {
+                const moduleKind = getSymbolKind('module');
+                const wsModules =
+                    (await commands.executeCommand<SymbolInformation[]>(
+                        'vscode.executeWorkspaceSymbolProvider',
+                        `¤${word}`,
+                        token
+                    )) || [];
+                const moduleLocs = wsModules.filter((s) => s.kind === moduleKind).map((x) => x.location);
+                if (moduleLocs.length) return moduleLocs;
+            }
+
+            // Conversely, the instance *name* is its own declaration — there is no
+            // definition to navigate to — so only the module type should be
+            // clickable (issue #242). Suppress go-to-definition when the click is on
+            // the instance name: a type token (not a declaration keyword), an
+            // optional parameter list, then this word, then a port list '('.
+            const declKeyword =
+                /^(?:module|macromodule|interface|program|package|primitive|config|checker|class|function|task|property|sequence|modport|typedef|import|export|extern|virtual|static|automatic)$/;
+            const typeBefore = beforeWord.match(/^\s*([a-zA-Z_][\w:]*)\s*(?:#\s*\([\s\S]*?\)\s*)?$/);
+            const isInstanceName =
+                !!typeBefore && !declKeyword.test(typeBefore[1]) && /^\s*(?:\[[^\]]*\]\s*)*\(/.test(afterWord);
+            if (isInstanceName) return [];
+
             // Default path: look in the current document first, then workspace.
             const docSyms =
                 (await commands.executeCommand<Array<DocumentSymbol | SymbolInformation>>(

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -190,4 +190,53 @@ suite('Extension Tests', () => {
             assert.fail('Definition not found');
         }
     });
+
+    test('test #10: DefinitionProvider instance name matching module name (#242)', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'instance_name_equals_module.sv'));
+
+        // Ctrl+click on the module *type* of "my_test_module my_test_module (...)"
+        // should resolve to the module definition (line 3), not the instance (line 10).
+        const symbolPosition = new vscode.Position(10, 5);
+
+        const definition = (await vscode.commands.executeCommand(
+            'vscode.executeDefinitionProvider',
+            uri,
+            symbolPosition
+        )) as vscode.Location[];
+
+        if ('length' in definition && definition.length > 0) {
+            // The fix resolves to the module definition only (line 3), not the
+            // same-named instance — so exactly one location, on line 3.
+            assert.strictEqual(
+                definition.length,
+                1,
+                'Expected exactly the module definition, got ' + definition.length
+            );
+            assert.strictEqual(
+                definition[0].range.start.line,
+                3,
+                'Expected the module definition on line 3, got line ' + definition[0].range.start.line
+            );
+        } else {
+            assert.fail('Definition not found');
+        }
+    });
+
+    test('test #11: DefinitionProvider instance name is not clickable (#242)', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'instance_name_equals_module.sv'));
+
+        // Ctrl+click on the instance *name* (second token) of
+        // "my_test_module my_test_module (...)" should resolve to nothing.
+        const symbolPosition = new vscode.Position(10, 20);
+
+        const definition = (await vscode.commands.executeCommand(
+            'vscode.executeDefinitionProvider',
+            uri,
+            symbolPosition
+        )) as vscode.Location[];
+
+        if ('length' in definition) {
+            assert.strictEqual(0, definition.length, 'Expected no definition on the instance name');
+        }
+    });
 });

--- a/verilog-examples/instance_name_equals_module.sv
+++ b/verilog-examples/instance_name_equals_module.sv
@@ -1,0 +1,15 @@
+// Regression example for issue #242: an instance given the same name as its
+// module type. Ctrl+click on the module type (first token) of the
+// instantiation should jump to the module definition below, not the instance.
+module my_test_module (
+  input  clk,
+  output q
+);
+endmodule
+
+module top;
+  my_test_module my_test_module (
+    .clk (clk),
+    .q   (q)
+  );
+endmodule


### PR DESCRIPTION
When a module is instantiated with an instance name identical to the module type, e.g. "my_test_module my_test_module (...)", ctrl-clicking the type resolved to the same-named local instance instead of the module definition.

DefinitionProvider now:
- detects a click on the type position of an instantiation (first token on the line, an optional parameter list, the instance name, then '(' or '#') and resolves it to the module definition via the workspace index, filtered to the module symbol kind; and
- treats the instance name itself as a non-target (the name is its own declaration), so only the module type is clickable.

Adds verilog-examples/instance_name_equals_module.sv and tests #10 (type -> module definition) and #11 (instance name -> no definition).

Fixes #242