### PR TITLE
Add setting to disable custom file icons (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ More details can be found on the [Releases](https://github.com/eirikpre/VSCode-S
 * Fixed syntax highlighting of verbose port declarations such as `input wire logic clock` ([#254](https://github.com/eirikpre/VSCode-SystemVerilog/issues/254)) by @joecrop
 * Added Workspace Trust support so syntax highlighting and indexing work in untrusted workspaces ([#262](https://github.com/eirikpre/VSCode-SystemVerilog/issues/262)) by @joecrop
 * Fixed go-to-definition on a module instantiation: the module type now resolves to the module definition (even when the instance shares its name), and the instance name itself is no longer treated as a navigation target ([#242](https://github.com/eirikpre/VSCode-SystemVerilog/issues/242)) by @joecrop
+* Added a `systemverilog.fileIcons` setting to disable the custom file-type icons in the Explorer and editor tabs ([#226](https://github.com/eirikpre/VSCode-SystemVerilog/issues/226)) by @joecrop
 
 ### [0.14.0]
 

--- a/package.json
+++ b/package.json
@@ -300,6 +300,11 @@
                         "default": false,
                         "description": "Disable automatic indexing when opening a folder or workspace."
                     },
+                    "systemverilog.fileIcons": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Show custom file icons for Verilog/SystemVerilog file types in the Explorer and editor tabs. Disable to fall back to your file icon theme's default icons. Changing this rewrites the extension manifest and requires a window reload."
+                    },
                     "systemverilog.includeIndexing": {
                         "type": "array",
                         "default": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { SystemVerilogReferenceProvider } from './providers/ReferenceProvider';
 import { SystemVerilogModuleInstantiator } from './providers/ModuleInstantiator';
 import { SystemVerilogIndexer } from './indexer';
 import { IndexerClient } from './utils/indexer-client';
+import { applyIconPreference } from './file-icons';
 
 // The LSP's client
 let client: LanguageClient;
@@ -42,6 +43,46 @@ function resolveStorageDir(context: ExtensionContext): string {
         /* mkdir is best-effort */
     }
     return dir;
+}
+
+/**
+    Reconcile the custom file-icon contributions with the
+    `systemverilog.fileIcons` setting (issue #226). VS Code has no runtime
+    toggle for `contributes.languages[].icon`, so we rewrite the extension's own
+    package.json to add/remove the icons and offer a reload. Idempotent: only
+    writes (and prompts) when the manifest does not already match the setting.
+*/
+async function syncFileIcons(context: ExtensionContext): Promise<void> {
+    const enabled = workspace.getConfiguration().get<boolean>('systemverilog.fileIcons', true);
+    const manifestPath = path.join(context.extensionPath, 'package.json');
+
+    let manifest: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    try {
+        manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    } catch {
+        return; // manifest unreadable — nothing we can do
+    }
+
+    if (!applyIconPreference(manifest, enabled)) {
+        return; // already in the desired state
+    }
+
+    try {
+        fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 4)}\n`);
+    } catch {
+        window.showWarningMessage(
+            'SystemVerilog: could not update the file-icon setting because the extension files are not writable.'
+        );
+        return;
+    }
+
+    const choice = await window.showInformationMessage(
+        `SystemVerilog file icons ${enabled ? 'enabled' : 'disabled'}. Reload the window to apply.`,
+        'Reload Window'
+    );
+    if (choice === 'Reload Window') {
+        commands.executeCommand('workbench.action.reloadWindow');
+    }
 }
 
 export function activate(context: ExtensionContext) {
@@ -100,6 +141,17 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(commands.registerCommand('systemverilog.build_index', buildHandler));
     context.subscriptions.push(commands.registerCommand('systemverilog.auto_instantiate', instantiateHandler));
     context.subscriptions.push(commands.registerCommand('systemverilog.compile', compileOpenedDocument));
+
+    // Reconcile custom file icons with the user's preference now, and whenever
+    // the `systemverilog.fileIcons` setting changes (issue #226).
+    syncFileIcons(context);
+    context.subscriptions.push(
+        workspace.onDidChangeConfiguration((e) => {
+            if (e.affectsConfiguration('systemverilog.fileIcons')) {
+                syncFileIcons(context);
+            }
+        })
+    );
 
     // Background Processes
     context.subscriptions.push(

--- a/src/file-icons.ts
+++ b/src/file-icons.ts
@@ -1,0 +1,57 @@
+// Custom file-type icons are contributed declaratively via
+// `contributes.languages[].icon` in package.json. VS Code has no runtime/`when`
+// switch for those, so to let users turn them off (issue #226) the extension
+// rewrites its own manifest to add or remove the `icon` entries and asks for a
+// window reload. This module holds the canonical icon map and the pure manifest
+// transform; the IO + reload prompt live in extension.ts.
+
+export interface LanguageIcon {
+    light: string;
+    dark: string;
+}
+
+// language id -> icon resources, mirroring the entries originally shipped in
+// package.json. Languages absent here (e.g. vhdl) never get a custom icon.
+export const FILE_ICON_MAP: Record<string, LanguageIcon> = {
+    systemverilog: { light: './resources/sv_light.svg', dark: './resources/sv_dark.svg' },
+    systemverilogheader: { light: './resources/svh_light.svg', dark: './resources/svh_dark.svg' },
+    verilog: { light: './resources/v_light.svg', dark: './resources/v_dark.svg' },
+    verilogheader: { light: './resources/vh_light.svg', dark: './resources/vh_dark.svg' },
+    verilogams: { light: './resources/vams.svg', dark: './resources/vams.svg' },
+    veriloga: { light: './resources/va.svg', dark: './resources/va.svg' },
+    'verilog-filelist': { light: './resources/f_light.svg', dark: './resources/f_dark.svg' },
+    sdc: { light: './resources/sdc_light.svg', dark: './resources/sdc_dark.svg' },
+    xdc: { light: './resources/sdc_light.svg', dark: './resources/sdc_dark.svg' }
+};
+
+/**
+    Add (`enabled`) or remove (`!enabled`) the custom `icon` entry on each
+    contributed language so the manifest matches the user's preference.
+    Pure and idempotent — no IO.
+    @param manifest a parsed package.json object (mutated in place)
+    @param enabled whether the custom file icons should be present
+    @return true if the manifest was changed, false if it already matched
+*/
+export function applyIconPreference(
+    manifest: { contributes?: { languages?: Array<{ id: string; icon?: LanguageIcon }> } },
+    enabled: boolean
+): boolean {
+    const langs = manifest?.contributes?.languages;
+    if (!Array.isArray(langs)) {
+        return false;
+    }
+    let changed = false;
+    for (const lang of langs) {
+        const wanted = enabled ? FILE_ICON_MAP[lang.id] : undefined;
+        if (wanted) {
+            if (!lang.icon || lang.icon.light !== wanted.light || lang.icon.dark !== wanted.dark) {
+                lang.icon = { light: wanted.light, dark: wanted.dark };
+                changed = true;
+            }
+        } else if (lang.icon !== undefined) {
+            delete lang.icon;
+            changed = true;
+        }
+    }
+    return changed;
+}

--- a/src/test/file-icons.test.ts
+++ b/src/test/file-icons.test.ts
@@ -1,0 +1,51 @@
+import * as assert from 'assert';
+import { applyIconPreference, FILE_ICON_MAP, LanguageIcon } from '../file-icons';
+
+type Lang = { id: string; icon?: LanguageIcon };
+type Manifest = { contributes: { languages: Lang[] } };
+
+function manifestWithIcons(): Manifest {
+    return {
+        contributes: {
+            languages: [
+                { id: 'systemverilog', icon: { ...FILE_ICON_MAP.systemverilog } },
+                { id: 'verilog', icon: { ...FILE_ICON_MAP.verilog } },
+                { id: 'vhdl' } // never carries a custom icon
+            ]
+        }
+    };
+}
+
+suite('file-icons Tests', () => {
+    test('test #1: disabling removes icons and reports a change', () => {
+        const manifest = manifestWithIcons();
+        const changed = applyIconPreference(manifest, false);
+        assert.strictEqual(changed, true);
+        assert.strictEqual(manifest.contributes.languages[0].icon, undefined);
+        assert.strictEqual(manifest.contributes.languages[1].icon, undefined);
+    });
+
+    test('test #2: re-enabling restores icons from the map', () => {
+        const manifest: Manifest = {
+            contributes: { languages: [{ id: 'systemverilog' }, { id: 'verilog' }, { id: 'vhdl' }] }
+        };
+        const changed = applyIconPreference(manifest, true);
+        assert.strictEqual(changed, true);
+        assert.deepStrictEqual(manifest.contributes.languages[0].icon, FILE_ICON_MAP.systemverilog);
+        assert.deepStrictEqual(manifest.contributes.languages[1].icon, FILE_ICON_MAP.verilog);
+        // A language with no mapping stays icon-less.
+        assert.strictEqual(manifest.contributes.languages[2].icon, undefined);
+    });
+
+    test('test #3: idempotent — no change when already in the desired state', () => {
+        assert.strictEqual(applyIconPreference(manifestWithIcons(), true), false);
+        const stripped = manifestWithIcons();
+        applyIconPreference(stripped, false);
+        assert.strictEqual(applyIconPreference(stripped, false), false);
+    });
+
+    test('test #4: tolerates a manifest without contributed languages', () => {
+        assert.strictEqual(applyIconPreference({}, true), false);
+        assert.strictEqual(applyIconPreference({ contributes: {} }, false), false);
+    });
+});


### PR DESCRIPTION
VS Code has no runtime/`when` toggle for `contributes.languages[].icon`, so the new boolean setting `systemverilog.fileIcons` (default true) is honored by rewriting the extension's own package.json to add or remove the icon entries and prompting a window reload.

- file-icons.ts holds the canonical language->icon map and a pure, idempotent `applyIconPreference(manifest, enabled)` transform.
- extension.ts reconciles the manifest with the setting on activation and on configuration change, writing only when it differs and warning if the extension files are read-only.

Adds unit tests for the manifest transform.

Fixes #226