### PR TITLE
Fix highlighting broken by nested parens in port connections (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ More details can be found on the [Releases](https://github.com/eirikpre/VSCode-S
 * Added Workspace Trust support so syntax highlighting and indexing work in untrusted workspaces ([#262](https://github.com/eirikpre/VSCode-SystemVerilog/issues/262)) by @joecrop
 * Fixed go-to-definition on a module instantiation: the module type now resolves to the module definition (even when the instance shares its name), and the instance name itself is no longer treated as a navigation target ([#242](https://github.com/eirikpre/VSCode-SystemVerilog/issues/242)) by @joecrop
 * Added a `systemverilog.fileIcons` setting to disable the custom file-type icons in the Explorer and editor tabs ([#226](https://github.com/eirikpre/VSCode-SystemVerilog/issues/226)) by @joecrop
+* Fixed syntax highlighting breaking on lines following a port connection that contains nested parentheses, such as `.data(func(a, b))` ([#188](https://github.com/eirikpre/VSCode-SystemVerilog/issues/188)) by @joecrop
 
 ### [0.14.0]
 

--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -666,6 +666,7 @@ repository:
         name: support.function.port.systemverilog
     end: \),?
     patterns:
+      - include: '#balanced-parens'
       - include: '#constants'
       - include: '#comments'
       - include: '#operators'
@@ -678,6 +679,23 @@ repository:
         name: storage.modifier.systemverilog
       - include: '#identifiers'
     name: meta.port.binding.systemverilog
+  balanced-parens:
+    # Consume a parenthesised sub-expression as a unit so that nested
+    # parentheses inside a port connection (e.g. `.p(func(a, b))`) do not let
+    # the enclosing rule's `end: \),?` match an inner `)` and corrupt the
+    # following lines (issue #188). Recurses to handle arbitrary nesting.
+    begin: \(
+    end: \)
+    patterns:
+      - include: '#balanced-parens'
+      - include: '#constants'
+      - include: '#comments'
+      - include: '#operators'
+      - include: '#strings'
+      - include: '#storage-scope'
+      - include: '#cast-operator'
+      - include: '#system-tf'
+      - include: '#identifiers'
   parameters:
     begin: '[ \t\r\n]*(#)[ \t\r\n]*(\()'
     beginCaptures:

--- a/verilog-examples/nested_paren_ports.sv
+++ b/verilog-examples/nested_paren_ports.sv
@@ -1,0 +1,18 @@
+// Regression example for issue #188: nested parentheses inside a port
+// connection used to make the highlighter end the binding at the first ')',
+// which corrupted the highlighting of the following lines. Every port name
+// below should highlight as a port, and the lines after a nested-paren
+// connection should be unaffected.
+module nested_paren_ports;
+
+    my_mod u_mod (
+        .clk    (clk),
+        .data   (func(a, b)),              // nested call
+        .enable (sel ? foo(x) : bar(y)),   // multiple nested calls
+        .bus    ({a, b[3:0], c}),          // concatenation
+        .deep   (f(g(h(x)))),              // deeply nested
+        .calc   ((a + b) * (c - d)),       // grouped sub-expressions
+        .out    (result)                   // must still be a port
+    );
+
+endmodule


### PR DESCRIPTION
The module-binding rule (.port(...)) ended at the first ')' (end: \),?), so a connection whose value contained nested parentheses, e.g. .data(func(a, b)), terminated at an inner ')'. The leftover unbalanced ')' popped the enclosing module-instantiation scope and corrupted the highlighting of the following lines.

Add a recursive #balanced-parens rule and consume nested '(...)' as a unit inside module-binding, so the binding only ends at its true closing paren.

Adds verilog-examples/nested_paren_ports.sv covering nested calls, concatenations, deep nesting and grouped sub-expressions.

Fixes #188