### PR TITLE
Fix `ifdef/`else/`endif code folding (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ More details can be found on the [Releases](https://github.com/eirikpre/VSCode-S
 * Fixed go-to-definition on a module instantiation: the module type now resolves to the module definition (even when the instance shares its name), and the instance name itself is no longer treated as a navigation target ([#242](https://github.com/eirikpre/VSCode-SystemVerilog/issues/242)) by @joecrop
 * Added a `systemverilog.fileIcons` setting to disable the custom file-type icons in the Explorer and editor tabs ([#226](https://github.com/eirikpre/VSCode-SystemVerilog/issues/226)) by @joecrop
 * Fixed syntax highlighting breaking on lines following a port connection that contains nested parentheses, such as `.data(func(a, b))` ([#188](https://github.com/eirikpre/VSCode-SystemVerilog/issues/188)) by @joecrop
+* Fixed code folding of `` `ifdef ``/`` `else ``/`` `endif `` blocks: an `` `ifdef `` now folds to its matching `` `endif `` with correct nesting instead of overrunning ([#142](https://github.com/eirikpre/VSCode-SystemVerilog/issues/142)) by @joecrop
 
 ### [0.14.0]
 

--- a/configs/systemVerilog.json
+++ b/configs/systemVerilog.json
@@ -50,8 +50,8 @@
     ],
     "folding": {
         "markers": {
-            "start": "^[ \\t\\n]*(?://[ \\t\\n]*#?region|`(?:ifdef|ifndef|elsif|else)\\b|\\b(?:(?:macro)?module|class)\\b)",
-            "end": "^[ \\t\\n]*(?://[ \\t\\n]*#?endregion|`(?:elsif|else|endif)\\b|\\b(?:endmodule|endclass)\\b)"
+            "start": "^[ \\t\\n]*(?://[ \\t\\n]*#?region\\b|`(?:ifdef|ifndef)\\b|\\b(?:(?:macro)?module|class)\\b)",
+            "end": "^[ \\t\\n]*(?://[ \\t\\n]*#?endregion\\b|`endif\\b|\\b(?:endmodule|endclass)\\b)"
         }
     }
 }

--- a/src/test/folding.test.ts
+++ b/src/test/folding.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const examplesFolderLocation = '../../verilog-examples';
+
+suite('Folding Tests', () => {
+    test('test #1: nested `ifdef/`elsif/`else/`endif fold with correct nesting (#142)', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'ifdef_folding.sv'));
+        await vscode.workspace.openTextDocument(uri);
+        const ranges =
+            ((await vscode.commands.executeCommand(
+                'vscode.executeFoldingRangeProvider',
+                uri
+            )) as vscode.FoldingRange[]) || [];
+        const dump = JSON.stringify(ranges.map((r) => [r.start, r.end]));
+        const has = (start: number, end: number) => ranges.some((r) => r.start === start && r.end === end);
+
+        // Each `ifdef/`ifndef folds to its own matching `endif, nested:
+        //   guard [0,20] > class [2,19] > `ifdef A [4,17] > `ifdef B [6,12]
+        assert.ok(has(6, 12), 'nested `ifdef B should fold to `endif // B [6,12]; got ' + dump);
+        assert.ok(has(4, 17), '`ifdef A should fold to `endif // A [4,17]; got ' + dump);
+        assert.ok(has(2, 19), 'class should fold to endclass [2,19]; got ' + dump);
+        assert.ok(has(0, 20), '`ifndef guard should fold to its `endif [0,20]; got ' + dump);
+
+        // `elsif/`else must not let a fold overrun its matching `endif.
+        assert.ok(!ranges.some((r) => r.start === 6 && r.end > 12), 'nested `ifdef B must not overrun; got ' + dump);
+        assert.ok(!ranges.some((r) => r.start === 4 && r.end > 17), '`ifdef A must not overrun; got ' + dump);
+    });
+});

--- a/verilog-examples/ifdef_folding.sv
+++ b/verilog-examples/ifdef_folding.sv
@@ -1,0 +1,21 @@
+`ifndef COMP_GUARD
+`define COMP_GUARD
+  class x
+    function z
+      `ifdef A
+        behavior_1
+        `ifdef B
+          behavior_1b
+        `elsif C
+          behavior_1c
+        `else // B
+          behavior_1d
+        `endif // B
+      `elsif D
+        behavior_2
+      `else // A
+        behavior_3
+      `endif // A
+    endfunction
+  endclass
+`endif // COMP_GUARD


### PR DESCRIPTION
The folding markers listed `else`/`elsif` in BOTH the start and end patterns. VS Code's marker folding tests the start pattern first, so a line matching both is treated as a region start only — `else`/`elsif` pushed a new region instead of closing the `ifdef`, leaving the `ifdef` to be closed by a later, mismatched `endif`/`endclass`. The result: `ifdef A` folded past its own `endif //A`, and the enclosing `ifndef` guard never folded at all.

Drop `else`/`elsif` from the markers so `ifdef`/`ifndef` pair with `endif`, nesting correctly (and add word boundaries to the region markers). VS Code's marker folding cannot close-and-reopen on one line, so the else/elsif branches no longer get their own sub-fold — an acceptable trade for correct nesting.

Adds verilog-examples/ifdef_folding.sv with nested `ifdef`s and `elsif`/`else` branches, plus a folding test via executeFoldingRangeProvider asserting the nested folds guard[0,20] > class[2,19] > `ifdef A[4,17] > `ifdef B[6,12] and no overrun.

Fixes #142