### PR TITLE
Index modules with a package import or comment in the header (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ More details can be found on the [Releases](https://github.com/eirikpre/VSCode-S
 * Added a `systemverilog.fileIcons` setting to disable the custom file-type icons in the Explorer and editor tabs ([#226](https://github.com/eirikpre/VSCode-SystemVerilog/issues/226)) by @joecrop
 * Fixed syntax highlighting breaking on lines following a port connection that contains nested parentheses, such as `.data(func(a, b))` ([#188](https://github.com/eirikpre/VSCode-SystemVerilog/issues/188)) by @joecrop
 * Fixed code folding of `` `ifdef ``/`` `else ``/`` `endif `` blocks: an `` `ifdef `` now folds to its matching `` `endif `` with correct nesting instead of overrunning ([#142](https://github.com/eirikpre/VSCode-SystemVerilog/issues/142)) by @joecrop
+* Fixed go-to-definition and hover failing for modules whose ANSI header contains a package import or a comment before the parameter list, e.g. `module foo import pkg::*; #(...)` ([#189](https://github.com/eirikpre/VSCode-SystemVerilog/issues/189)) by @joecrop
 
 ### [0.14.0]
 

--- a/src/parser-core.ts
+++ b/src/parser-core.ts
@@ -94,6 +94,11 @@ export class SystemVerilogParser {
             /(?:automatic\s+)?/,
             ')',
             /(?<name>\w+)/,
+            // ANSI module headers may carry package-import declarations and/or
+            // comments between the name and the parameter/port lists (issue
+            // #189). Consume any number of them (non-capturing so the `end\1`
+            // back-reference to the `type` group is unaffected).
+            /(?:\s*(?:\/\/[^\n]*|\/\*[\w\W]*?\*\/|import\s+\w+\s*::\s*[\w*]+(?:\s*,\s*\w+\s*::\s*[\w*]+)*\s*;))*/,
             /(?<params>\s*#\s*\([\w\W]*?\))?/,
             /(?<ports>\s*\([\W\w]*?\))?/,
             /\s*;/,

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -239,4 +239,29 @@ suite('Extension Tests', () => {
             assert.strictEqual(0, definition.length, 'Expected no definition on the instance name');
         }
     });
+
+    test('test #12: DefinitionProvider on instance of a module with an import header (#189)', async () => {
+        const uri = vscode.Uri.file(path.join(__dirname, examplesFolderLocation, 'import_header_module.sv'));
+
+        // Ctrl+click on the `myfoo` type of "myfoo #(.z(3)) u_foo (...)" (line 18)
+        // should resolve to the module definition (line 7), even though the
+        // module's header carries a package import and a comment.
+        const symbolPosition = new vscode.Position(18, 6);
+
+        const definition = (await vscode.commands.executeCommand(
+            'vscode.executeDefinitionProvider',
+            uri,
+            symbolPosition
+        )) as vscode.Location[];
+
+        if ('length' in definition && definition.length > 0) {
+            assert.strictEqual(
+                definition[0].range.start.line,
+                7,
+                'Expected the module definition on line 7, got line ' + definition[0].range.start.line
+            );
+        } else {
+            assert.fail('Definition not found for module with import in header');
+        }
+    });
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -11,8 +11,20 @@ suite('Extension Tests', () => {
         const waitFor = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
         // Trigger indexing, this returns when command is triggered and not when indexing is complete
         await vscode.commands.executeCommand('systemverilog.build_index');
-        // Wait for indexing to (hopefully) be complete
-        await waitFor(400);
+        // Indexing is asynchronous. Rather than a fixed delay (which races on slow
+        // CI machines and made later lookups flaky), poll until a known workspace
+        // symbol is available, with a generous timeout.
+        const deadline = Date.now() + 30000;
+        while (Date.now() < deadline) {
+            // eslint-disable-next-line no-await-in-loop
+            const syms = (await vscode.commands.executeCommand(
+                'vscode.executeWorkspaceSymbolProvider',
+                '¤pa_Package'
+            )) as vscode.SymbolInformation[];
+            if (syms && syms.length > 0) break;
+            // eslint-disable-next-line no-await-in-loop
+            await waitFor(200);
+        }
     });
 
     test('test #2: moduleFromPort', async () => {

--- a/src/test/index-coverage.ts
+++ b/src/test/index-coverage.ts
@@ -23,6 +23,9 @@ export async function run(): Promise<void> {
     const mocha = new Mocha({
         ui: 'tdd',
         color: true,
+        // Integration tests wait for asynchronous workspace indexing; allow
+        // ample time so slower CI machines don't hit the 2s default.
+        timeout: 60000,
         reporter: 'mocha-multi-reporters',
         reporterOptions: {
             reporterEnabled: 'spec, xunit',

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -10,6 +10,9 @@ export function run(): Promise<void> {
     const mocha = new Mocha({
         ui: 'tdd',
         color: true,
+        // Integration tests wait for asynchronous workspace indexing; allow
+        // ample time so slower CI machines don't hit the 2s default.
+        timeout: 60000,
         reporter: 'mocha-multi-reporters',
         reporterOptions: {
             reporterEnabled: 'spec, xunit',

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -1,0 +1,70 @@
+import * as assert from 'assert';
+import { SystemVerilogParser, StringSource } from '../parser-core';
+
+function symbols(text: string) {
+    return new SystemVerilogParser().parse(new StringSource(text, '/tmp/x.sv'), 'full', 10);
+}
+function moduleNames(text: string): string[] {
+    return symbols(text)
+        .filter((s) => s.type === 'module')
+        .map((s) => s.name);
+}
+
+suite('Parser Tests', () => {
+    test('test #1: module with a package import in the header is indexed (#189)', () => {
+        const text =
+            'module foo\n  import foo_pkg::*;\n#(parameter z = 1) (\n  input logic x,\n  output logic y\n);\nendmodule\n';
+        assert.deepStrictEqual(moduleNames(text), ['foo']);
+    });
+
+    test('test #2: module with a comment in the header is indexed (#189)', () => {
+        const text =
+            'module foo //this comment used to break the parser\n#(parameter z = 1) (\n  input x\n);\nendmodule\n';
+        assert.deepStrictEqual(moduleNames(text), ['foo']);
+    });
+
+    test('test #3: module with multiple/comma-separated imports is indexed (#189)', () => {
+        const text =
+            'module foo\n  import a_pkg::*;\n  import b_pkg::item, c_pkg::*;\n#(parameter z = 1)(input x);\nendmodule\n';
+        assert.deepStrictEqual(moduleNames(text), ['foo']);
+    });
+
+    test('test #4: a plain module still indexes its params and ports', () => {
+        const text = 'module foo #(parameter z = 1)(input logic x, output logic y);\nendmodule\n';
+        const syms = symbols(text);
+        assert.ok(
+            syms.some((s) => s.type === 'module' && s.name === 'foo'),
+            'module foo indexed'
+        );
+        assert.ok(
+            syms.some((s) => s.name === 'z' && s.container === 'foo'),
+            'parameter z under foo'
+        );
+        assert.ok(
+            syms.some((s) => s.name === 'x' && s.container === 'foo'),
+            'port x under foo'
+        );
+        assert.ok(
+            syms.some((s) => s.name === 'y' && s.container === 'foo'),
+            'port y under foo'
+        );
+    });
+
+    test('test #5: a module with an import header still indexes its params and ports (#189)', () => {
+        const text =
+            'module foo\n  import foo_pkg::*;\n#(parameter z = 1) (\n  input logic x,\n  output logic y\n);\nendmodule\n';
+        const syms = symbols(text);
+        assert.ok(
+            syms.some((s) => s.name === 'z' && s.container === 'foo'),
+            'parameter z under foo'
+        );
+        assert.ok(
+            syms.some((s) => s.name === 'x' && s.container === 'foo'),
+            'port x under foo'
+        );
+        assert.ok(
+            syms.some((s) => s.name === 'y' && s.container === 'foo'),
+            'port y under foo'
+        );
+    });
+});

--- a/verilog-examples/import_header_module.sv
+++ b/verilog-examples/import_header_module.sv
@@ -1,0 +1,23 @@
+// Example for issue #189: a module whose ANSI header carries a package import
+// (and a comment) before the parameter/port lists. The module must still be
+// indexed so go-to-definition and hover work on its instantiation below.
+package foo_pkg;
+    parameter int WIDTH = 8;
+endpackage
+
+module myfoo
+    import foo_pkg::*;          // import in the header used to break the parser
+#(
+    parameter z = 1
+) (
+    input  logic x,
+    output logic y
+);
+endmodule
+
+module top;
+    myfoo #(.z(3)) u_foo (
+        .x (x),
+        .y (y)
+    );
+endmodule


### PR DESCRIPTION
The module-declaration regex in parser-core.ts allowed nothing between the module name and the parameter/port lists, so an ANSI header carrying a package import (e.g. `module foo import foo_pkg::*; #(...)`) or a comment (`module foo //note`) failed to match. The module was never indexed, so go-to-definition and hover did not work on its instantiations.

Consume any number of package-import declarations and comments between the name and the parameter/port lists. The clause is non-capturing so the `end\1` back-reference (to the `type` group) is unaffected, and params/ports are still extracted under the module.

Adds parser unit tests and verilog-examples/import_header_module.sv.

Fixes #189